### PR TITLE
move cache function to RepresentationHandler

### DIFF
--- a/spark/src/main/java/io/spark/ddf/SparkDDF.java
+++ b/spark/src/main/java/io/spark/ddf/SparkDDF.java
@@ -107,29 +107,29 @@ public class SparkDDF extends DDF {
     }
   }
 
-  public Boolean isCached() {
-    HiveContext hiveContext = ((SparkDDFManager) this.getManager()).getHiveContext();
-    try {
-      return hiveContext.isCached(this.getTableName());
-    } catch (Exception e) {
-      return false;
-    }
-  }
-
-  public void cacheTable() throws DDFException {
-    this.saveAsTable();
-    HiveContext hiveContext = ((SparkDDFManager) this.getManager()).getHiveContext();
-    hiveContext.cacheTable(this.getTableName());
-  }
-
-  public void unCacheTable() {
-    try {
-      HiveContext hiveContext = ((SparkDDFManager) this.getManager()).getHiveContext();
-      hiveContext.uncacheTable(this.getTableName());
-    } catch (IllegalArgumentException e) {
-
-    }
-  }
+//  public Boolean isCached() {
+//    HiveContext hiveContext = ((SparkDDFManager) this.getManager()).getHiveContext();
+//    try {
+//      return hiveContext.isCached(this.getTableName());
+//    } catch (Exception e) {
+//      return false;
+//    }
+//  }
+//
+//  public void cacheTable() throws DDFException {
+//    this.saveAsTable();
+//    HiveContext hiveContext = ((SparkDDFManager) this.getManager()).getHiveContext();
+//    hiveContext.cacheTable(this.getTableName());
+//  }
+//
+//  public void unCacheTable() {
+//    try {
+//      HiveContext hiveContext = ((SparkDDFManager) this.getManager()).getHiveContext();
+//      hiveContext.uncacheTable(this.getTableName());
+//    } catch (IllegalArgumentException e) {
+//
+//    }
+//  }
 
   @SuppressWarnings({ "rawtypes", "unchecked" })
   public IGetResult getJavaRDD(Class<?>... acceptableUnitTypes) throws DDFException {

--- a/spark/src/main/java/io/spark/ddf/SparkDDF.java
+++ b/spark/src/main/java/io/spark/ddf/SparkDDF.java
@@ -107,30 +107,6 @@ public class SparkDDF extends DDF {
     }
   }
 
-//  public Boolean isCached() {
-//    HiveContext hiveContext = ((SparkDDFManager) this.getManager()).getHiveContext();
-//    try {
-//      return hiveContext.isCached(this.getTableName());
-//    } catch (Exception e) {
-//      return false;
-//    }
-//  }
-//
-//  public void cacheTable() throws DDFException {
-//    this.saveAsTable();
-//    HiveContext hiveContext = ((SparkDDFManager) this.getManager()).getHiveContext();
-//    hiveContext.cacheTable(this.getTableName());
-//  }
-//
-//  public void unCacheTable() {
-//    try {
-//      HiveContext hiveContext = ((SparkDDFManager) this.getManager()).getHiveContext();
-//      hiveContext.uncacheTable(this.getTableName());
-//    } catch (IllegalArgumentException e) {
-//
-//    }
-//  }
-
   @SuppressWarnings({ "rawtypes", "unchecked" })
   public IGetResult getJavaRDD(Class<?>... acceptableUnitTypes) throws DDFException {
     IGetResult result = this.getRDD(acceptableUnitTypes);

--- a/spark/src/main/java/io/spark/ddf/etl/SqlHandler.java
+++ b/spark/src/main/java/io/spark/ddf/etl/SqlHandler.java
@@ -48,11 +48,7 @@ public class SqlHandler extends ASqlHandler {
       mLog.info(">>>>>> get table for ddf");
       DDF ddf = this.getManager().getDDF(tableName);
       if (ddf != null) {
-        SchemaRDD rdd = (SchemaRDD) ddf.getRepresentationHandler().get(SchemaRDD.class);
-        if (rdd == null) {
-          throw new DDFException("Error getting SchemaRDD");
-        }
-        ((SparkDDF) ddf).cacheTable();
+        ((SparkDDF) ddf).saveAsTable();
       }
     } catch (Exception e) {
       mLog.info(">>>> Exception e.message = " + e.getMessage());
@@ -111,7 +107,6 @@ public class SqlHandler extends ASqlHandler {
     }
 
     if (dataSource == null) {
-
       rdd = this.getHiveContext().sql(command);
     } else {
       // TODO
@@ -124,12 +119,8 @@ public class SqlHandler extends ASqlHandler {
 
     DDF ddf = this.getManager().newDDF(this.getManager(), rdd, new Class<?>[] {SchemaRDD.class}, null,
         tableName, schema);
-    ((SparkDDF) ddf).cacheTable();
+    ((SparkDDF) ddf).saveAsTable();
 
-    //get RDD<Row> from the cacheTable SchemaRDD is faster than recompute from reading from disk.
-    //and more memory efficient than cache the original SchemaRDD
-    RDD<Row> rddRow = this.getHiveContext().sql(String.format("select * from %s", ddf.getTableName()));
-    ddf.getRepresentationHandler().add(rddRow, RDD.class, Row.class);
     this.getManager().addDDF(ddf);
     return ddf;
   }

--- a/spark/src/main/scala/io/spark/ddf/content/RepresentationHandler.scala
+++ b/spark/src/main/scala/io/spark/ddf/content/RepresentationHandler.scala
@@ -4,6 +4,8 @@
 package io.spark.ddf.content
 
 import java.lang.Class
+import io.spark.ddf.{SparkDDFManager, SparkDDF}
+
 import scala.reflect.Manifest
 import scala.collection.JavaConversions._
 import io.spark.ddf.content.RepresentationHandler._
@@ -66,6 +68,16 @@ class RepresentationHandler(mDDF: DDF) extends RH(mDDF) {
         }
       } //f(kv._2.asInstanceOf[RDD[_]])
     }
+  }
+
+  /**
+   * Cache SchemaRDD in memory
+   * */
+  override def cache = {
+    val ddf = this.getDDF.asInstanceOf[SparkDDF]
+    ddf.saveAsTable()
+    val schemaRDD = ddf.getRepresentationHandler.get(classOf[SchemaRDD]).asInstanceOf[SchemaRDD]
+    schemaRDD.persist()
   }
 
   override def cacheAll = {


### PR DESCRIPTION
RepresentationHandler.cache() will cache the underlying SchemaRDD