### PR TITLE
Keep column in order

### DIFF
--- a/spark/src/test/java/io/spark/ddf/analytics/BinningHandlerTest.java
+++ b/spark/src/test/java/io/spark/ddf/analytics/BinningHandlerTest.java
@@ -35,7 +35,7 @@ public class BinningHandlerTest extends BaseTest {
     Assert.assertTrue(ddf1.getSchemaHandler().getColumn("month").getColumnClass() == ColumnClass.FACTOR);
     // {'[2,4]'=1, '(4,6]'=2, '(6,8]'=3}
     System.out.println(">>>>> get2,4) == " + ddf1.getSchemaHandler().getColumn("month").getOptionalFactor().getLevelMap().get("[2,4]"));
-	Assert.assertTrue(ddf1.getSchemaHandler().getColumn("month").getOptionalFactor().getLevelMap().get("[2,4]") == 1);
+	Assert.assertTrue(ddf1.getSchemaHandler().getColumn("month").getOptionalFactor().getLevelMap().get("[2,4]") == 2);
 
     Assert.assertFalse(Strings.isNullOrEmpty(newddf.sql2txt("select dayofweek from @this", "").get(0)));
     Assert.assertFalse(Strings.isNullOrEmpty(ddf1.sql2txt("select month from @this", "").get(0)));

--- a/spark/src/test/java/io/spark/ddf/etl/TransformationHandlerTest.java
+++ b/spark/src/test/java/io/spark/ddf/etl/TransformationHandlerTest.java
@@ -88,7 +88,7 @@ public class TransformationHandlerTest extends BaseTest {
 
     Assert.assertEquals(31, ddf.getNumRows());
     Assert.assertEquals(9, ddf.getNumColumns());
-    Assert.assertEquals("test123", ddf.getColumnName(0));
+    Assert.assertEquals("test123", ddf.getColumnName(8));
     Assert.assertEquals(9, ddf.VIEWS.head(1).get(0).split("\\t").length);
 
 
@@ -112,7 +112,7 @@ public class TransformationHandlerTest extends BaseTest {
 
     Assert.assertEquals(31, ddf.getNumRows());
     Assert.assertEquals(9, ddf.getNumColumns());
-    Assert.assertEquals("dist", ddf.getColumnName(0));
+    Assert.assertEquals("dist", ddf.getColumnName(8));
     Assert.assertEquals(9, ddf.VIEWS.head(1).get(0).split("\\t").length);
 
     // udf without assigning column name
@@ -127,14 +127,14 @@ public class TransformationHandlerTest extends BaseTest {
     ddf = ddf.Transform.transformUDF("speed = distance/(arrtime-deptime)", cols);
     Assert.assertEquals(31, ddf.getNumRows());
     Assert.assertEquals(5, ddf.getNumColumns());
-    Assert.assertEquals("speed", ddf.getColumnName(0));
+    Assert.assertEquals("speed", ddf.getColumnName(4));
     ddf.setMutable(false);
 
     // multiple expressions, column name with special characters
     DDF ddf3 = ddf.Transform.transformUDF("arrtime-deptime, (speed^*- = distance/(arrtime-deptime)", cols);
     Assert.assertEquals(31, ddf3.getNumRows());
     Assert.assertEquals(6, ddf3.getNumColumns());
-    Assert.assertEquals("speed", ddf3.getColumnName(1));
+    Assert.assertEquals("speed", ddf3.getColumnName(5));
     Assert.assertEquals(6, ddf3.getSummary().length);
 
     // transform using if else/case when
@@ -158,5 +158,11 @@ public class TransformationHandlerTest extends BaseTest {
     ddf.setMutable(true);
     List<String> cols = Lists.newArrayList("distance");
     ddf.Transform.transformUDF("distance=100", cols);
+  }
+
+  @Test(expected=RuntimeException.class)
+  public void testConflictingColumnDefinitions2() throws DDFException {
+    ddf.setMutable(true);
+    ddf.Transform.transformUDF("distance=100, distance");
   }
 }


### PR DESCRIPTION
Besides move new columns added through transformHive to the end of the schema. Some more checks are added to defend against inconsistencies.

transformUDF takes in two parameters: RExp, and a list of selected columns

new columns can be added in both the RExp and the list, so we should defend against duplicate/conflicting columns in RExp or in the list or across them(throw exception). We should really get rid of the second parameter; it doesn't make sense to me and it require a lot more effort to make sure nothing weird happens.

Right now there's still one minor case left:
1. ddf.Transfrom.transformUDF("arrtime, speed=distance/airtime")
2. ddf.Transfrom.transformUDF("speed=distance/airtime")
These two will produce same output, because any existing columns selected in the RExp part(meaning just column name and no '=' followed by a new definition) will be effectively ignored, since RExp is a place to specify new definition for an existing column or a new column. A filter is done only if the a list is provided.

The above issue has always been there. Before, we could also duplicate columns through the list or the RExp.

@nhanitvn @mbbui please review.