### PR TITLE
fix writing ddf to text used in sql2txt and fetchRows, head, etc. 

### DIFF
--- a/spark/src/main/scala/io/spark/ddf/util/SparkUtils.scala
+++ b/spark/src/main/scala/io/spark/ddf/util/SparkUtils.scala
@@ -182,11 +182,18 @@ object SparkUtils {
     var i = 0
     rowSchema.zip(row.toSeq).foreach {
       case (_, null) =>
+        if(i > 0)
+          gen.writeRaw(separator)
+        i = i+1
+        gen.writeNull()
       case (field, v) =>
         if(i > 0)
           gen.writeRaw(separator)
         i = i+1
-        valWriter(field.dataType, v)
+        if(field.dataType.isPrimitive)
+          gen.writeRaw(v.toString)
+        else
+          valWriter(field.dataType, v)
     }
     gen.close()
     writer.toString


### PR DESCRIPTION
Fix this issue: https://adatao.atlassian.net/browse/PE-577

**Cause of the issue**: with complex data type in DDF, it uses general json writer to print out the content of DDF which add quotes to every string. 

**Result of the fix**
- string value is no longer in quote
- column with null value is included as 'null' instead of being ignored

