### PR TITLE
DDFSPARK_JAR now can contain directories in addition to files

### DIFF
--- a/spark/src/main/java/io/spark/ddf/util/Utils.java
+++ b/spark/src/main/java/io/spark/ddf/util/Utils.java
@@ -1,8 +1,40 @@
 package io.spark.ddf.util;
 
 
-public class Utils {
+import java.io.File;
+import java.io.FilenameFilter;
+import java.util.ArrayList;
+import java.util.Arrays;
 
+public class Utils {
+  public static ArrayList<String> listJars(String directory) {
+
+    String workingDir = System.getProperty("user.dir");
+    // Support relative path too
+    final String completeDirectory = directory.startsWith("/")?directory:workingDir+directory;
+    File dir = new File(directory);
+
+    FilenameFilter filter = new FilenameFilter() {
+      public boolean accept
+          (File dir, String name) {
+        // only accept jar files
+        return ((new File(completeDirectory+"/"+name).list() == null )&&(name.endsWith(".jar")));
+      }
+    };
+
+    String[] children = dir.list(filter);
+    if (children == null) {
+      System.out.println("Either dir does not exist or is not a directory");
+      return null;
+    }
+    else {
+      ArrayList<String> jars = new ArrayList<String>();
+      for(String jar: children) {
+        jars.add(directory+"/" + jar);
+      }
+      return jars;
+    }
+  }
 }
 
 


### PR DESCRIPTION
In case of Databricks Cloud, the uploaded jar file is renamed by DBC by adding an UUID prefix. Also, itdoes not exist on the master node at the time init scripts are run, we can only know the directory where it will be copied, not the exact full path. So it is necessary that we can just specify the directory and let the DDF app search for the jar at run-time.