### PR TITLE
Standardizing output of sql2txt with all dependencies addressed

### DIFF
--- a/core/src/main/java/io/ddf/DDF.java
+++ b/core/src/main/java/io/ddf/DDF.java
@@ -980,9 +980,13 @@ public abstract class DDF extends ALoggable //
     return this.getStatisticsSupporter().getVectorMean(columnName);
   }
 
+  // for backward compatibility
   public List<HistogramBin> getVectorHistogram_Hive(String columnName, int numBins) throws DDFException {
+    return getVectorApproxHistogram(columnName, numBins);
+  }
+  public List<HistogramBin> getVectorApproxHistogram(String columnName, int numBins) throws DDFException {
     // TODO need to check columnName
-    return this.getBinningHandler().getVectorHistogram_Hive(columnName, numBins);
+    return this.getBinningHandler().getVectorApproxHistogram(columnName, numBins);
 
   }
 

--- a/core/src/main/java/io/ddf/DDF.java
+++ b/core/src/main/java/io/ddf/DDF.java
@@ -982,7 +982,7 @@ public abstract class DDF extends ALoggable //
 
   public List<HistogramBin> getVectorHistogram_Hive(String columnName, int numBins) throws DDFException {
     // TODO need to check columnName
-    return this.getStatisticsSupporter().getVectorHistogram(columnName, numBins);
+    return this.getBinningHandler().getVectorHistogram_Hive(columnName, numBins);
 
   }
 

--- a/core/src/main/java/io/ddf/analytics/ABinningHandler.java
+++ b/core/src/main/java/io/ddf/analytics/ABinningHandler.java
@@ -16,12 +16,10 @@ public abstract class ABinningHandler extends ADDFFunctionalGroupHandler impleme
     // TODO Auto-generated constructor stub
   }
 
-  public List<AStatisticsSupporter.HistogramBin> getVectorHistogram(String column, int numBins) throws DDFException{
-    List<AStatisticsSupporter.HistogramBin> bins = getVectorHistogramImpl(column, numBins);
-    return bins;
-  }
+  public abstract List<AStatisticsSupporter.HistogramBin> getVectorHistogram(String column, int numBins)
+          throws DDFException;
 
-  public abstract List<AStatisticsSupporter.HistogramBin> getVectorHistogramImpl(String column, int numBins)
+  public abstract List<AStatisticsSupporter.HistogramBin> getVectorHistogram_Hive(String column, int numBins)
           throws DDFException;
 
   public DDF binning(String column, String binningType, int numBins, double[] breaks, boolean includeLowest,

--- a/core/src/main/java/io/ddf/analytics/ABinningHandler.java
+++ b/core/src/main/java/io/ddf/analytics/ABinningHandler.java
@@ -19,7 +19,7 @@ public abstract class ABinningHandler extends ADDFFunctionalGroupHandler impleme
   public abstract List<AStatisticsSupporter.HistogramBin> getVectorHistogram(String column, int numBins)
           throws DDFException;
 
-  public abstract List<AStatisticsSupporter.HistogramBin> getVectorHistogram_Hive(String column, int numBins)
+  public abstract List<AStatisticsSupporter.HistogramBin> getVectorApproxHistogram(String column, int numBins)
           throws DDFException;
 
   public DDF binning(String column, String binningType, int numBins, double[] breaks, boolean includeLowest,

--- a/core/src/main/java/io/ddf/analytics/AStatisticsSupporter.java
+++ b/core/src/main/java/io/ddf/analytics/AStatisticsSupporter.java
@@ -59,7 +59,7 @@ public abstract class AStatisticsSupporter extends ADDFFunctionalGroupHandler im
       // or "min \t max \t null"s
       String[] rs = this.getDDF()
           .sql2txt(command, String.format("Unable to get fivenum summary of the given columns from table %%s")).get(0)
-          .replaceAll("ArrayBuffer|\\(|\\)|\\[|\\]|,", "").split("\t| ");
+          .replaceAll("\\[|\\]| ", "").replaceAll(",", "\t").split("\t| ");
 
 
       int k = 0;

--- a/core/src/main/java/io/ddf/analytics/AStatisticsSupporter.java
+++ b/core/src/main/java/io/ddf/analytics/AStatisticsSupporter.java
@@ -152,7 +152,7 @@ public abstract class AStatisticsSupporter extends ADDFFunctionalGroupHandler im
     String command = String.format("select corr(%s, %s) from @this", xColumnName, yColumnName);
     if (!Strings.isNullOrEmpty(command)) {
       List<String> result = this.getDDF().sql2txt(command,
-          String.format("Unable to compute correlation of %s and %s from table %%s", xColumnName, yColumnName));
+              String.format("Unable to compute correlation of %s and %s from table %%s", xColumnName, yColumnName));
       if (result != null && !result.isEmpty() && result.get(0) != null) {
         corr = Double.parseDouble(result.get(0));
         return corr;
@@ -167,7 +167,7 @@ public abstract class AStatisticsSupporter extends ADDFFunctionalGroupHandler im
     String command = String.format("select  covar_samp(%s, %s) from @this", xColumnName, yColumnName);
     if (!Strings.isNullOrEmpty(command)) {
       List<String> result = this.getDDF().sql2txt(command,
-          String.format("Unable to compute covariance of %s and %s from table %%s", xColumnName, yColumnName));
+              String.format("Unable to compute covariance of %s and %s from table %%s", xColumnName, yColumnName));
       if (result != null && !result.isEmpty() && result.get(0) != null) {
         System.out.println(">>>>> parseDouble: " + result.get(0));
         cov = Double.parseDouble(result.get(0));
@@ -177,6 +177,7 @@ public abstract class AStatisticsSupporter extends ADDFFunctionalGroupHandler im
     return Double.NaN;
   }
 
+/*
   @Override
   public List<HistogramBin> getVectorHistogram(String columnName, int numBins) throws DDFException {
     String command = String.format("select histogram_numeric(%s,%s) from @this", columnName, numBins);
@@ -202,6 +203,8 @@ public abstract class AStatisticsSupporter extends ADDFFunctionalGroupHandler im
     }
     return null;
   }
+*/
+
 
   private double parseDouble(String s) {
     mLog.info(">>>> parseDouble: " + s);

--- a/core/src/main/java/io/ddf/analytics/AStatisticsSupporter.java
+++ b/core/src/main/java/io/ddf/analytics/AStatisticsSupporter.java
@@ -329,7 +329,7 @@ public abstract class AStatisticsSupporter extends ADDFFunctionalGroupHandler im
 
     mLog.info("Column type: " + colType);
     List<Double> pValues = Arrays.asList(percentiles);
-    Pattern p1 = Pattern.compile("(big|small|tiny|int)");
+    Pattern p1 = Pattern.compile("(big|small|tiny|int|long)");
     Pattern p2 = Pattern.compile("(float|double)");
 
     String min = "";

--- a/core/src/main/java/io/ddf/analytics/AStatisticsSupporter.java
+++ b/core/src/main/java/io/ddf/analytics/AStatisticsSupporter.java
@@ -357,7 +357,7 @@ public abstract class AStatisticsSupporter extends ADDFFunctionalGroupHandler im
         pParams = "percentile_approx(" + columnName + ", array(" + StringUtils.join(pValues, ",") + "), " + B.toString()
             + ")";
       } else {
-        throw new DDFException("Only support numeric verctors!!!");
+        throw new DDFException("Only support numeric vectors!!!");
       }
     }
 
@@ -384,8 +384,8 @@ public abstract class AStatisticsSupporter extends ADDFFunctionalGroupHandler im
       throw new DDFException("Cannot get vector quantiles from SQL queries");
     }
     String[] convertedResults = rs.get(0)
-        .replaceAll("ArrayBuffer|\\(|\\)|\\[|\\]|,", "")
-        .replace("null", "NULL, NULL, NULL").split("\t| ");
+        .replaceAll("\\[|\\]| ", "").replaceAll(",", "\t")
+        .replace("null", "NULL, NULL, NULL").split("\t");
     mLog.info("Raw info " + StringUtils.join(rs, "\n"));
 
     Double[] result = new Double[percentiles.length];

--- a/core/src/main/java/io/ddf/analytics/IHandleBinning.java
+++ b/core/src/main/java/io/ddf/analytics/IHandleBinning.java
@@ -13,5 +13,5 @@ public interface IHandleBinning extends IHandleDDFFunctionalGroup {
       boolean right) throws DDFException;
 
     public List<AStatisticsSupporter.HistogramBin> getVectorHistogram(String column, int numBins) throws DDFException;
-    public List<AStatisticsSupporter.HistogramBin> getVectorHistogram_Hive(String column, int numBins) throws DDFException;
+    public List<AStatisticsSupporter.HistogramBin> getVectorApproxHistogram(String column, int numBins) throws DDFException;
 }

--- a/core/src/main/java/io/ddf/analytics/IHandleBinning.java
+++ b/core/src/main/java/io/ddf/analytics/IHandleBinning.java
@@ -13,4 +13,5 @@ public interface IHandleBinning extends IHandleDDFFunctionalGroup {
       boolean right) throws DDFException;
 
     public List<AStatisticsSupporter.HistogramBin> getVectorHistogram(String column, int numBins) throws DDFException;
+    public List<AStatisticsSupporter.HistogramBin> getVectorHistogram_Hive(String column, int numBins) throws DDFException;
 }

--- a/core/src/main/java/io/ddf/analytics/ISupportStatistics.java
+++ b/core/src/main/java/io/ddf/analytics/ISupportStatistics.java
@@ -26,7 +26,7 @@ public interface ISupportStatistics extends IHandleDDFFunctionalGroup {
 
   public double getVectorCovariance(String xColumnName, String yColumnName) throws DDFException;
 
-  public List<HistogramBin> getVectorHistogram(String columnName, int numBins) throws DDFException;
+  //public List<HistogramBin> getVectorHistogram(String columnName, int numBins) throws DDFException;
 
   public Double getVectorMin(String columnName) throws DDFException;
 

--- a/project/RootBuild.scala
+++ b/project/RootBuild.scala
@@ -18,7 +18,7 @@ object RootBuild extends Build {
   val DEFAULT_HADOOP_VERSION = "2.2.0"
 
 
-  val SPARK_VERSION = "1.3.5-adatao"
+  val SPARK_VERSION = "1.3.1"
 
   val YARN_ENABLED = env("SPARK_YARN").getOrElse("true").toBoolean
 

--- a/project/RootBuild.scala
+++ b/project/RootBuild.scala
@@ -18,7 +18,7 @@ object RootBuild extends Build {
   val DEFAULT_HADOOP_VERSION = "2.2.0"
 
 
-  val SPARK_VERSION = "1.3.1"
+  val SPARK_VERSION = "1.3.5-adatao"
 
   val YARN_ENABLED = env("SPARK_YARN").getOrElse("true").toBoolean
 

--- a/spark/src/main/java/io/spark/ddf/etl/SqlHandler.java
+++ b/spark/src/main/java/io/spark/ddf/etl/SqlHandler.java
@@ -112,8 +112,8 @@ public class SqlHandler extends ASqlHandler {
   }
 
   //TODO SparkSql
-  @Override
-  public List<String> sql2txt(String command, Integer maxRows, String dataSource) throws DDFException {
+  //@Override
+  public List<String> sql2txt_old(String command, Integer maxRows, String dataSource) throws DDFException {
     DataFrame rdd = ((SparkDDFManager) this.getManager()).getHiveContext().sql(command);
     Row[] arrRow = rdd.collect();
     List<String> lsString = new ArrayList<String>();
@@ -124,8 +124,9 @@ public class SqlHandler extends ASqlHandler {
     return lsString;
   }
 
-
-  public List<String> sql2txt_new(String command, Integer maxRows, String dataSource) throws DDFException {
+  //TODO SparkSql
+  @Override
+  public List<String> sql2txt(String command, Integer maxRows, String dataSource) throws DDFException {
     DataFrame rdd = ((SparkDDFManager) this.getManager()).getHiveContext().sql(command);
     String[] strResult = SparkUtils.jsonForComplexType(rdd, "\t");
     return Arrays.asList(strResult);

--- a/spark/src/main/java/io/spark/ddf/etl/SqlHandler.java
+++ b/spark/src/main/java/io/spark/ddf/etl/SqlHandler.java
@@ -114,6 +114,7 @@ public class SqlHandler extends ASqlHandler {
   //TODO SparkSql
   @Override
   public List<String> sql2txt(String command, Integer maxRows, String dataSource) throws DDFException {
+    //System.out.println("run sql2txt: \n" + command);
     DataFrame rdd = ((SparkDDFManager) this.getManager()).getHiveContext().sql(command);
     String[] strResult = SparkUtils.jsonForComplexType(rdd, "\t");
     return Arrays.asList(strResult);

--- a/spark/src/main/java/io/spark/ddf/etl/SqlHandler.java
+++ b/spark/src/main/java/io/spark/ddf/etl/SqlHandler.java
@@ -112,19 +112,6 @@ public class SqlHandler extends ASqlHandler {
   }
 
   //TODO SparkSql
-  //@Override
-  public List<String> sql2txt_old(String command, Integer maxRows, String dataSource) throws DDFException {
-    DataFrame rdd = ((SparkDDFManager) this.getManager()).getHiveContext().sql(command);
-    Row[] arrRow = rdd.collect();
-    List<String> lsString = new ArrayList<String>();
-
-    for (Row row : arrRow) {
-      lsString.add(row.mkString("\t"));
-    }
-    return lsString;
-  }
-
-  //TODO SparkSql
   @Override
   public List<String> sql2txt(String command, Integer maxRows, String dataSource) throws DDFException {
     DataFrame rdd = ((SparkDDFManager) this.getManager()).getHiveContext().sql(command);

--- a/spark/src/main/scala/io/spark/ddf/analytics/BinningHandler.scala
+++ b/spark/src/main/scala/io/spark/ddf/analytics/BinningHandler.scala
@@ -46,13 +46,13 @@ class BinningHandler(mDDF: DDF) extends ABinningHandler(mDDF) with IHandleBinnin
     mLog.info(">>>> getVectorHistogram command = " + command)
     val ddf: DDF = this.getDDF.sql2ddf(command)
     mLog.info(ddf.VIEWS.head(1).toString)
-    val rdd: RDD[Row] = ddf.getRepresentationHandler.get(classOf[RDD[_]], classOf[Row]).asInstanceOf[RDD[Row]]
+    val rddbins = ddf.getRepresentationHandler.get(classOf[RDD[_]], classOf[Row]).asInstanceOf[RDD[Row]].collect
+    val histbins = rddbins(0).get(0).asInstanceOf[ArrayBuffer[Row]]
 
-    val rddbins = rdd.collect()(0)(0).asInstanceOf[ArrayBuffer[Array[Double]]]
-    val bins = rddbins.map(r => {
+    val bins = histbins.map(r => {
       val b = new AStatisticsSupporter.HistogramBin
-      b.setX(r(0))
-      b.setY(r(1))
+      b.setX(r.get(0).asInstanceOf[Double])
+      b.setY(r.get(1).asInstanceOf[Double])
       b
     })
     return bins.toList.asJava

--- a/spark/src/main/scala/io/spark/ddf/analytics/BinningHandler.scala
+++ b/spark/src/main/scala/io/spark/ddf/analytics/BinningHandler.scala
@@ -148,8 +148,7 @@ class BinningHandler(mDDF: DDF) extends ABinningHandler(mDDF) with IHandleBinnin
 
   def getIntervalsFromNumBins(colName: String, bins: Int): Array[Double] = {
     val cmd = "SELECT min(%s), max(%s) FROM %s".format(colName, colName, mDDF.getTableName)
-    val res: Array[Double] = mDDF.sql2txt(cmd, "").get(0).replace("ArrayBuffer", "").
-      replace("(", "").replace(")", "").replace(", ", "\t").split("\t").map(x ⇒ x.toDouble)
+    val res: Array[Double] = mDDF.sql2txt(cmd, "").get(0).split("\t").map(x ⇒ x.toDouble)
     val (min, max) = (res(0), res(1))
     val eachInterval = (max - min) / bins
     val probs: Array[Double] = Array.fill[Double](bins + 1)(0)
@@ -182,7 +181,7 @@ class BinningHandler(mDDF: DDF) extends ABinningHandler(mDDF) with IHandleBinnin
     pArray.foreach(x ⇒ cmd = cmd + x.toString + ",")
     cmd = cmd.take(cmd.length - 1)
     cmd = String.format("min(%s), percentile_approx(%s, array(%s)), max(%s)", colName, colName, cmd, colName)
-    mDDF.sql2txt("SELECT " + cmd + " FROM @this", "").get(0).replaceAll("ArrayBuffer|\\(|\\)|,", "").split("\t| ").
+    mDDF.sql2txt("SELECT " + cmd + " FROM @this", "").get(0).replaceAll("\\[|\\]| ", "").replaceAll(",", "\t").split("\t").
       map(x ⇒ x.toDouble)
   }
 

--- a/spark/src/main/scala/io/spark/ddf/analytics/BinningHandler.scala
+++ b/spark/src/main/scala/io/spark/ddf/analytics/BinningHandler.scala
@@ -40,7 +40,7 @@ class BinningHandler(mDDF: DDF) extends ABinningHandler(mDDF) with IHandleBinnin
 
   }
 
-  override def getVectorHistogram_Hive(columnName: String, numBins: Int): java.util.List[AStatisticsSupporter.HistogramBin] = {
+  override def getVectorApproxHistogram(columnName: String, numBins: Int): java.util.List[AStatisticsSupporter.HistogramBin] = {
     val command: String = s"select histogram_numeric($columnName,$numBins) from @this"
 
     mLog.info(">>>> getVectorHistogram command = " + command)

--- a/spark/src/main/scala/io/spark/ddf/util/SparkUtils.scala
+++ b/spark/src/main/scala/io/spark/ddf/util/SparkUtils.scala
@@ -131,8 +131,9 @@ object SparkUtils {
    */
   def jsonForComplexType(df: DataFrame, sep: String): Array[String] = {
     val schema = df.schema
-    val df1: RDD[String] = df.map(r => rowToJSON(schema, r, sep))
-    df1.collect()
+    //val df1: RDD[String] = df.map(r => rowToJSON(schema, r, sep)) // run in parallel
+    //df1.collect()
+    df.collect().map(r => rowToJSON(schema, r, sep)) // run sequentially
   }
 
   private def rowToJSON(rowSchema: StructType, row: Row, separator: String): String = {

--- a/spark/src/test/java/io/spark/ddf/analytics/StatisticsSupporterTest.java
+++ b/spark/src/test/java/io/spark/ddf/analytics/StatisticsSupporterTest.java
@@ -2,8 +2,6 @@ package io.spark.ddf.analytics;
 
 
 import io.ddf.DDF;
-import io.ddf.DDFManager;
-import io.ddf.analytics.AStatisticsSupporter.FiveNumSummary;
 import io.ddf.analytics.AStatisticsSupporter.HistogramBin;
 import io.ddf.analytics.Summary;
 import io.ddf.exception.DDFException;
@@ -106,9 +104,9 @@ public class StatisticsSupporterTest extends BaseTest {
   }
 
   @Test
-  public void testVectorHistogram_Hive() throws DDFException {
-    System.out.println(">>>>> testVectorHistogram_Hive");
-    List<HistogramBin> bins = ddf1.getVectorHistogram_Hive("arrdelay", 5);
+  public void testVectorApproxHistogram() throws DDFException {
+    System.out.println(">>>>> testVectorApproxHistogram");
+    List<HistogramBin> bins = ddf1.getVectorApproxHistogram("arrdelay", 5);
     //for (int i = 0; i < bins.size(); i++)
     //  System.out.println(bins.get(i).getX() + " - " + bins.get(i).getY());
 

--- a/spark/src/test/java/io/spark/ddf/analytics/StatisticsSupporterTest.java
+++ b/spark/src/test/java/io/spark/ddf/analytics/StatisticsSupporterTest.java
@@ -106,6 +106,7 @@ public class StatisticsSupporterTest extends BaseTest {
 
   @Test
   public void testVectorHistogram_Hive() throws DDFException {
+    System.out.println(">>>>> testVectorHistogram_Hive");
     List<HistogramBin> bins = ddf1.getVectorHistogram_Hive("arrdelay", 5);
     for (int i = 0; i < bins.size(); i++) {
       System.out.println(bins.get(i).getX() + " - " + bins.get(i).getY());
@@ -118,10 +119,7 @@ public class StatisticsSupporterTest extends BaseTest {
 
   @Test
   public void testVectorHistogram() throws DDFException {
-    //createTableMovie();
-    //mdf = manager.sql2ddf("select year, length, rating, votes from movie");
-    //List<HistogramBin> bins = mdf.getVectorHistogram("length", 5);
-
+    System.out.println(">>>>> testVectorHistogram");
     List<HistogramBin> bins = ddf1.getVectorHistogram("arrdelay", 5);
     for (int i = 0; i < bins.size(); i++) {
       System.out.println(bins.get(i).getX() + " - " + bins.get(i).getY());

--- a/spark/src/test/java/io/spark/ddf/analytics/StatisticsSupporterTest.java
+++ b/spark/src/test/java/io/spark/ddf/analytics/StatisticsSupporterTest.java
@@ -94,23 +94,24 @@ public class StatisticsSupporterTest extends BaseTest {
     System.out.println(">>>>> testVectorCovariance = " + a);
   }
 
-//  @Test
-//  public void testVectorQuantiles() throws DDFException {
-//    // Double[] quantiles = ddf1.getVectorQuantiles("deptime", {0.3, 0.5, 0.7});
-//    Double[] pArray = { 0.3, 0.5, 0.7 };
-//    Double[] expectedQuantiles = { 801.0, 1416.0, 1644.0 };
-//    Double[] quantiles = ddf1.getVectorQuantiles("deptime", pArray);
-//    System.out.println("Quantiles: " + StringUtils.join(quantiles, ", "));
-//    Assert.assertArrayEquals(expectedQuantiles, quantiles);
-//  }
+  @Test
+  public void testVectorQuantiles() throws DDFException {
+    System.out.println(">>>>> testVectorQuantiles");
+    // Double[] quantiles = ddf1.getVectorQuantiles("deptime", {0.3, 0.5, 0.7});
+    Double[] pArray = { 0.3, 0.5, 0.7 };
+    Double[] expectedQuantiles = { 801.0, 1416.0, 1644.0 };
+    Double[] quantiles = ddf1.getVectorQuantiles("deptime", pArray);
+    System.out.println("Quantiles: " + StringUtils.join(quantiles, ", "));
+    Assert.assertArrayEquals(expectedQuantiles, quantiles);
+  }
 
   @Test
   public void testVectorHistogram_Hive() throws DDFException {
     System.out.println(">>>>> testVectorHistogram_Hive");
     List<HistogramBin> bins = ddf1.getVectorHistogram_Hive("arrdelay", 5);
-    for (int i = 0; i < bins.size(); i++) {
-      System.out.println(bins.get(i).getX() + " - " + bins.get(i).getY());
-    }
+    //for (int i = 0; i < bins.size(); i++)
+    //  System.out.println(bins.get(i).getX() + " - " + bins.get(i).getY());
+
     Assert.assertEquals(5, bins.size());
     Assert.assertEquals(-12.45, bins.get(0).getX(), 0.01);
     Assert.assertEquals(11, bins.get(0).getY(), 0.01);
@@ -121,8 +122,11 @@ public class StatisticsSupporterTest extends BaseTest {
   public void testVectorHistogram() throws DDFException {
     System.out.println(">>>>> testVectorHistogram");
     List<HistogramBin> bins = ddf1.getVectorHistogram("arrdelay", 5);
-    for (int i = 0; i < bins.size(); i++) {
-      System.out.println(bins.get(i).getX() + " - " + bins.get(i).getY());
-    }
+    //for (int i = 0; i < bins.size(); i++)
+    //  System.out.println(bins.get(i).getX() + " - " + bins.get(i).getY());
+
+    Assert.assertEquals(5, bins.size());
+    Assert.assertEquals(-24, bins.get(0).getX(), 0.01);
+    Assert.assertEquals(10, bins.get(0).getY(), 0.01);
   }
 }

--- a/spark/src/test/scala/io/spark/ddf/content/ComplexTypeDDFSuite.scala
+++ b/spark/src/test/scala/io/spark/ddf/content/ComplexTypeDDFSuite.scala
@@ -115,46 +115,30 @@ class ComplexTypeDDFSuite extends ATestSuite {
     qdata.VIEWS.head(3).asScala.toList.foreach(println)
   }
 
-  test("test query result from flattened DDF with all columns from Smurf data") {
-    println("\n\n ================================= query result from flattened DDF with all columns on Smurf ")
-    val path = "../resources/test/smurf_pubsub_sample.json"
-    val ddf = json2ddf(path)
-    println("---ddf schema: \n" + ddf.getSchema.getColumnNames)
-    ddf.VIEWS.head(3).asScala.toList.foreach(println)
-
-    val fddf: DDF = ddf.getFlattenedDDF()
-    println("---flattened_ddf schema: \n" + fddf.getSchema.getColumnNames)
-    fddf.VIEWS.head(3).asScala.toList.foreach(println)
-
-    println("\n---- Query 4 elements from the flattenedDDF")
-    val qdata = fddf.sql2ddf(s"select * from ${fddf.getTableName} limit 4")
-    println("---query result from a flattened ddf: ")
-    println("schema: " + qdata.getSchema.getColumnNames)
-    println("data:")
-    qdata.VIEWS.head(3).asScala.toList.foreach(println)
-  }
   */
 
-  test("test query result from flattened DDF with all columns") {
-    println("\n\n ================================= query result from flattened DDF with all columns")
+  test("test some stats functions on flattened DDF") {
+    println("\n\n ================================= test some stats functions on flattened DDF")
     val path = "../resources/test/sleep_data_sample.json"
     val ddf = json2ddf(path)
-    println("---ddf schema: \n" + ddf.getSchema.getColumnNames)
-    ddf.VIEWS.head(3).asScala.toList.foreach(println)
-
     val fddf: DDF = ddf.getFlattenedDDF()
-    println("---flattened_ddf schema: \n" + fddf.getSchema.getColumnNames)
-    fddf.VIEWS.head(3).asScala.toList.foreach(println)
 
-    println("\n---- Query min, max, histogram from the flattenedDDF")
+    println("\nquery min, max, histogram from the flattenedDDF")
     val qdata = fddf.sql2txt(s"select min(data_realDeepSleepTimeInMinutes), max(data_realDeepSleepTimeInMinutes), avg(data_realDeepSleepTimeInMinutes), PERCENTILE(data_realDeepSleepTimeInMinutes, array(0, 1, 0.25, 0.5, 0.75)), histogram_numeric(data_realDeepSleepTimeInMinutes, 10) from ${fddf.getTableName}", "")
-    println("---query result from a flattened ddf: ")
     qdata.get(0).split("\t").foreach(println)
 
     val qdf = fddf.sql2ddf(s"select data_realDeepSleepTimeInMinutes from ${fddf.getTableName}")
     println("get FiveNum")
     qdf.getFiveNumSummary.foreach(x => {
       println(Array(x.getFirstQuantile, x.getMedian, x.getThirdQuantile).mkString(","))
+    })
+
+    println("get vectorQuantiles")
+    println(qdf.getVectorQuantiles(Array(0.25, 0.5, 0.75)).mkString(","))
+
+    println("get Summary")
+    qdf.getSummary.foreach(x => {
+      println(x.toString)
     })
   }
 

--- a/spark/src/test/scala/io/spark/ddf/content/ComplexTypeDDFSuite.scala
+++ b/spark/src/test/scala/io/spark/ddf/content/ComplexTypeDDFSuite.scala
@@ -7,6 +7,7 @@ import io.spark.ddf.util.SparkUtils
 import org.apache.spark.sql.Column
 import org.apache.spark.sql.DataFrame
 import io.ddf.DDF
+import org.junit.Assert
 import scala.collection.JavaConverters._
 /**
   */
@@ -95,7 +96,7 @@ class ComplexTypeDDFSuite extends ATestSuite {
     qdata.VIEWS.head(10).asScala.toList.foreach(println)
   }
 */
-  /*
+
   test("test query result from flattened DDF with all columns") {
     println("\n\n ================================= query result from flattened DDF with all columns")
     val path = "../resources/test/sleep_data_sample.json"
@@ -113,33 +114,6 @@ class ComplexTypeDDFSuite extends ATestSuite {
     println("schema: " + qdata.getSchema.getColumnNames)
     println("data:")
     qdata.VIEWS.head(3).asScala.toList.foreach(println)
-  }
-
-  */
-
-  test("test some stats functions on flattened DDF") {
-    println("\n\n ================================= test some stats functions on flattened DDF")
-    val path = "../resources/test/sleep_data_sample.json"
-    val ddf = json2ddf(path)
-    val fddf: DDF = ddf.getFlattenedDDF()
-
-    println("\nquery min, max, histogram from the flattenedDDF")
-    val qdata = fddf.sql2txt(s"select min(data_realDeepSleepTimeInMinutes), max(data_realDeepSleepTimeInMinutes), avg(data_realDeepSleepTimeInMinutes), PERCENTILE(data_realDeepSleepTimeInMinutes, array(0, 1, 0.25, 0.5, 0.75)), histogram_numeric(data_realDeepSleepTimeInMinutes, 10) from ${fddf.getTableName}", "")
-    qdata.get(0).split("\t").foreach(println)
-
-    val qdf = fddf.sql2ddf(s"select data_realDeepSleepTimeInMinutes from ${fddf.getTableName}")
-    println("get FiveNum")
-    qdf.getFiveNumSummary.foreach(x => {
-      println(Array(x.getFirstQuantile, x.getMedian, x.getThirdQuantile).mkString(","))
-    })
-
-    println("get vectorQuantiles")
-    println(qdf.getVectorQuantiles(Array(0.25, 0.5, 0.75)).mkString(","))
-
-    println("get Summary")
-    qdf.getSummary.foreach(x => {
-      println(x.toString)
-    })
   }
 
 

--- a/spark/src/test/scala/io/spark/ddf/content/SampleSuite.scala
+++ b/spark/src/test/scala/io/spark/ddf/content/SampleSuite.scala
@@ -6,7 +6,7 @@ import scala.collection.JavaConversions._
  */
 class SampleSuite extends ATestSuite {
   createTableMtcars()
-  test("test sample") {
+  test("test sample with numrows") {
     val ddf = manager.sql2ddf("select * from mtcars")
     val sample = ddf.VIEWS.getRandomSample(10)
 
@@ -14,5 +14,12 @@ class SampleSuite extends ATestSuite {
     assert(sample(1)(0).asInstanceOf[Double] != sample(2)(0).asInstanceOf[Double])
     assert(sample(2)(0).asInstanceOf[Double] != sample(3)(0).asInstanceOf[Double])
     assert(sample.length == 10)
+  }
+
+  test("test sample with percentage") {
+    val ddf = manager.sql2ddf("select * from mtcars")
+    val sample = ddf.VIEWS.getRandomSample(0.5, false, 1)
+    //sample.getSchema.getColumns.foreach(c => {println(c.getName + " - " + c.getType)})
+    sample.VIEWS.head(3).foreach(println)
   }
 }

--- a/spark/src/test/scala/io/spark/ddf/content/SampleSuite.scala
+++ b/spark/src/test/scala/io/spark/ddf/content/SampleSuite.scala
@@ -20,6 +20,7 @@ class SampleSuite extends ATestSuite {
     val ddf = manager.sql2ddf("select * from mtcars")
     val sample = ddf.VIEWS.getRandomSample(0.5, false, 1)
     //sample.getSchema.getColumns.foreach(c => {println(c.getName + " - " + c.getType)})
+    println("sample: ")
     sample.VIEWS.head(3).foreach(println)
   }
 }

--- a/spark/src/test/scala/io/spark/ddf/content/Sql2txtComplexDDFSuite.scala
+++ b/spark/src/test/scala/io/spark/ddf/content/Sql2txtComplexDDFSuite.scala
@@ -4,6 +4,7 @@ import io.ddf.DDF
 import io.spark.ddf.ATestSuite
 import io.spark.ddf.util.SparkUtils
 import org.apache.spark.sql.DataFrame
+import org.junit.Assert
 
 import scala.collection.JavaConverters._
 
@@ -36,16 +37,43 @@ class Sql2txtComplexDDFSuite extends ATestSuite {
     println("---ddf schema: \n" + ddf.getSchema.getColumnNames)
 
     println("---ddf values:")
-    val lddf = ddf.sql2txt("select * from @this limit 10", "")
+    val lddf = ddf.sql2txt("select * from @this limit 3", "")
     lddf.asScala.toList.foreach(println)
 
     val fddf: DDF = ddf.getFlattenedDDF()
     println("---flattened_ddf schema: \n" + fddf.getSchema.getColumnNames)
 
     println("---flattened_ddf values:")
-    val lfddf = fddf.sql2txt("select * from @this limit 10", "")
+    val lfddf = fddf.sql2txt("select * from @this limit 3", "")
     lfddf.asScala.toList.foreach(println)
   }
+
+  test("test some stats functions on flattened DDF") {
+    println("\n\n ================================= test some stats functions on flattened DDF")
+    val path = "../resources/test/sleep_data_sample.json"
+    val ddf = json2ddf(path)
+    val fddf: DDF = ddf.getFlattenedDDF()
+    val qdf = fddf.sql2ddf(s"select data_realDeepSleepTimeInMinutes from ${fddf.getTableName}")
+
+    val expectedArray = Array(122.0,183.5,241.75)
+    println("get FiveNum")
+    val fn = qdf.getFiveNumSummary
+    Assert.assertEquals(expectedArray(0), fn(0).getFirstQuantile)
+    Assert.assertEquals(expectedArray(1), fn(0).getMedian)
+    Assert.assertEquals(expectedArray(2), fn(0).getThirdQuantile)
+    fn.foreach(x => {println(Array(x.getFirstQuantile, x.getMedian, x.getThirdQuantile).mkString(","))})
+
+    println("get vectorQuantiles")
+    val vq = qdf.getVectorQuantiles(Array(0.25, 0.5, 0.75))
+    Assert.assertEquals(expectedArray(0), vq(0))
+    println(vq.mkString(","))
+
+    println("get Summary")
+    val sum = qdf.getSummary
+    sum.foreach(x => {println(x.toString)})
+  }
+
+
 
   def json2ddf(path:String): DDF = {
     val sqlCtx = manager.getHiveContext

--- a/spark/src/test/scala/io/spark/ddf/content/Sql2txtComplexDDFSuite.scala
+++ b/spark/src/test/scala/io/spark/ddf/content/Sql2txtComplexDDFSuite.scala
@@ -12,7 +12,7 @@ import scala.collection.JavaConverters._
   */
 class Sql2txtComplexDDFSuite extends ATestSuite {
 
-
+  /*
   test("test printout value of complex type dataframe using json") {
     println("\n\n ================================= test printout value of complex type dataframe using json")
     val path = "../resources/test/sleep_data_sample.json"
@@ -27,21 +27,25 @@ class Sql2txtComplexDDFSuite extends ATestSuite {
     println("--- sample dataframe with column data.sleepStateChanges only:")
     val strLst1 = SparkUtils.jsonForComplexType(df.select("data.sleepStateChanges"), "\t")
     strLst1.foreach(println)
-
   }
+  */
 
   test("test sql2txt with json for complex type DDF") {
     println("\n\n ================================= test sql2txt with json for complex type DDF")
     val path = "../resources/test/sleep_data_sample.json"
     val ddf = json2ddf(path)
-    println("---ddf schema: \n" + ddf.getSchema.getColumnNames)
+    val ddf_cols = ddf.getSchema.getColumnNames.toString
+    println("---ddf schema: \n" + ddf_cols)
+    Assert.assertEquals("[id, cid, created_at, data, itype, ts, u_at, uid]", ddf_cols)
 
     println("---ddf values:")
     val lddf = ddf.sql2txt("select * from @this limit 3", "")
     lddf.asScala.toList.foreach(println)
 
     val fddf: DDF = ddf.getFlattenedDDF()
-    println("---flattened_ddf schema: \n" + fddf.getSchema.getColumnNames)
+    val fddf_cols = fddf.getSchema.getColumnNames.toString
+    println("---flattened_ddf schema: \n" + fddf_cols)
+    Assert.assertEquals("[id_oid, cid, created_at_date, data_bookmarkTime, data_isFirstSleepOfDay, data_normalizedSleepQuality, data_realDeepSleepTimeInMinutes, data_realEndTime, data_realSleepTimeInMinutes, data_realStartTime, data_sleepStateChanges, itype, ts, u_at_date, uid_oid]", fddf_cols)
 
     println("---flattened_ddf values:")
     val lfddf = fddf.sql2txt("select * from @this limit 3", "")
@@ -58,19 +62,22 @@ class Sql2txtComplexDDFSuite extends ATestSuite {
     val expectedArray = Array(122.0,183.5,241.75)
     println("get FiveNum")
     val fn = qdf.getFiveNumSummary
-    Assert.assertEquals(expectedArray(0), fn(0).getFirstQuantile)
-    Assert.assertEquals(expectedArray(1), fn(0).getMedian)
-    Assert.assertEquals(expectedArray(2), fn(0).getThirdQuantile)
     fn.foreach(x => {println(Array(x.getFirstQuantile, x.getMedian, x.getThirdQuantile).mkString(","))})
+    Assert.assertEquals(expectedArray(0), fn(0).getFirstQuantile, 0.01)
+    Assert.assertEquals(expectedArray(1), fn(0).getMedian, 0.01)
+    Assert.assertEquals(expectedArray(2), fn(0).getThirdQuantile, 0.01)
 
     println("get vectorQuantiles")
     val vq = qdf.getVectorQuantiles(Array(0.25, 0.5, 0.75))
-    Assert.assertEquals(expectedArray(0), vq(0))
     println(vq.mkString(","))
+    Assert.assertEquals(expectedArray(0), vq(0), 0.01)
 
     println("get Summary")
     val sum = qdf.getSummary
     sum.foreach(x => {println(x.toString)})
+    Assert.assertEquals(189.59, sum(0).mean(), 0.01)
+    Assert.assertEquals(85.5, sum(0).stdev(), 0.01)
+    Assert.assertEquals(100, sum(0).count(), 0.01)
   }
 
 


### PR DESCRIPTION
Output of sql2txt is now in general/standard format. If a column is array, the output is "[..]". If a column is struct, the output is a json string. 

There are 5 dependencies on the old sql2txt. They have been updated wrt the new ouput format.
- getVectorQuantiles
- getFiveNumSummary
- 2 internal functions inside BinningHandler.java
- getVectorHistogram (using HiveSQ)

In which, getVectorHistogram is totally rewritten to avoid using sql2txt. 

All DDF unit tests are passed. 