### PR TITLE
Update DDF's transform to accept a list of expressions too

### DIFF
--- a/core/src/main/java/io/ddf/DDF.java
+++ b/core/src/main/java/io/ddf/DDF.java
@@ -363,6 +363,10 @@ public abstract class DDF extends ALoggable //
     return this.getTransformationHandler().flattenDDF();
   }
 
+  public DDF transform(List<String> transformExpressions) throws DDFException {
+    return Transform.transformUDF(transformExpressions);
+  }
+
   public DDF transform(String transformExpression) throws DDFException {
     return Transform.transformUDF(transformExpression);
   }

--- a/core/src/main/java/io/ddf/etl/IHandleTransformations.java
+++ b/core/src/main/java/io/ddf/etl/IHandleTransformations.java
@@ -17,6 +17,14 @@ public interface IHandleTransformations extends IHandleDDFFunctionalGroup {
 
   public DDF transformMapReduceNative(String mapFuncDef, String reduceFuncDef, boolean mapsideCombine);
 
+  /**
+   * Create new columns or overwrite existing ones
+   *
+   * @param transformExpressions A list of expressions, each is in format of column=expression or expression
+   * @param columns
+   * @return
+   * @throws DDFException
+   */
   public DDF transformUDF(List<String> transformExpressions, List<String> columns) throws DDFException;
 
   public DDF flattenDDF(String[] columns) throws DDFException;

--- a/core/src/main/java/io/ddf/etl/IHandleTransformations.java
+++ b/core/src/main/java/io/ddf/etl/IHandleTransformations.java
@@ -17,7 +17,7 @@ public interface IHandleTransformations extends IHandleDDFFunctionalGroup {
 
   public DDF transformMapReduceNative(String mapFuncDef, String reduceFuncDef, boolean mapsideCombine);
 
-  public DDF transformUDF(String transformExpression, List<String> columns) throws DDFException;
+  public DDF transformUDF(List<String> transformExpressions, List<String> columns) throws DDFException;
 
   public DDF flattenDDF(String[] columns) throws DDFException;
 

--- a/core/src/main/java/io/ddf/etl/TransformationHandler.java
+++ b/core/src/main/java/io/ddf/etl/TransformationHandler.java
@@ -9,11 +9,8 @@ import io.ddf.content.Schema.Column;
 import io.ddf.content.Schema.ColumnClass;
 import io.ddf.exception.DDFException;
 import io.ddf.misc.ADDFFunctionalGroupHandler;
-import java.util.List;
-import java.util.Map;
-import java.util.HashMap;
-import java.util.Set;
-import java.util.HashSet;
+
+import java.util.*;
 
 public class TransformationHandler extends ADDFFunctionalGroupHandler implements IHandleTransformations {
 
@@ -98,9 +95,9 @@ public class TransformationHandler extends ADDFFunctionalGroupHandler implements
     return flattenDDF(null);
   }
 
-  public DDF transformUDF(String RExp, List<String> columns) throws DDFException {
+  public DDF transformUDF(List<String> RExps, List<String> columns) throws DDFException {
     String sqlCmd = String.format("SELECT %s FROM %s",
-        RToSqlUdf(RExp, columns, this.getDDF().getSchema().getColumns()),
+        RToSqlUdf(RExps, columns, this.getDDF().getSchema().getColumns()),
         this.getDDF().getTableName());
 
     DDF newddf = this.getManager().sql2ddf(sqlCmd);
@@ -113,8 +110,8 @@ public class TransformationHandler extends ADDFFunctionalGroupHandler implements
     }
   }
 
-  public DDF transformUDF(String RExp) throws DDFException {
-    return transformUDF(RExp, null);
+  public DDF transformUDF(List<String> RExps) throws DDFException {
+    return transformUDF(RExps, null);
   }
 
   /**
@@ -124,7 +121,7 @@ public class TransformationHandler extends ADDFFunctionalGroupHandler implements
    * @return "(arrtime - crsarrtime) as foobar, (distance / airtime) as speed
    */
 
-  public static String RToSqlUdf(String RExp, List<String> selectedColumns, List<Column> existingColumns) {
+  public static String RToSqlUdf(List<String> RExps, List<String> selectedColumns, List<Column> existingColumns) {
     List<String> udfs = Lists.newArrayList();
     Map<String, String> newColToDef = new HashMap<String, String>();
     boolean updateOnConflict = (selectedColumns == null || selectedColumns.isEmpty());
@@ -144,7 +141,7 @@ public class TransformationHandler extends ADDFFunctionalGroupHandler implements
     }
 
     Set<String> newColsInRExp = new HashSet<String>();
-    for (String str : RExp.split(",(?![^()]*+\\))")) {
+    for (String str : RExps) {
       String[] udf = str.split("[=~](?![^()]*+\\))");
       String newCol = (udf.length > 1) ?
         udf[0].trim().replaceAll("\\W", "") :
@@ -177,7 +174,13 @@ public class TransformationHandler extends ADDFFunctionalGroupHandler implements
     return selectStr.substring(0, selectStr.length() - 1);
   }
 
-  public static String RToSqlUdf(String RExp) {
+  public static String RToSqlUdf(List<String> RExp) {
     return RToSqlUdf(RExp, null, null);
+  }
+
+  public static String RToSqlUdf(String RExp) {
+    List<String> RExps = new ArrayList<String>();
+    RExps.add(RExp);
+    return RToSqlUdf(RExps, null, null);
   }
 }

--- a/core/src/main/java/io/ddf/facades/TransformFacade.java
+++ b/core/src/main/java/io/ddf/facades/TransformFacade.java
@@ -83,6 +83,13 @@ public class TransformFacade implements IHandleTransformations {
     return mTransformationHandler.transformUDF(transformExpressions, columns);
   }
 
+  /**
+   * Create a new column or overwrite an existing one.
+   *
+   * @param transformExpression the expression in format column=expression
+   * @return a DDF
+   * @throws DDFException
+   */
   public DDF transformUDF(String transformExpression) throws DDFException {
     return transformUDF(transformExpression, null);
   }

--- a/core/src/main/java/io/ddf/facades/TransformFacade.java
+++ b/core/src/main/java/io/ddf/facades/TransformFacade.java
@@ -5,6 +5,7 @@ import io.ddf.DDF;
 import io.ddf.etl.IHandleTransformations;
 import io.ddf.exception.DDFException;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class TransformFacade implements IHandleTransformations {
@@ -66,10 +67,21 @@ public class TransformFacade implements IHandleTransformations {
   }
 
   @Override
-  public DDF transformUDF(String transformExpression, List<String> columns) throws DDFException {
-    return mTransformationHandler.transformUDF(transformExpression, columns);
+  public DDF transformUDF(List<String> transformExpressions, List<String> columns) throws DDFException {
+    return mTransformationHandler.transformUDF(transformExpressions, columns);
   }
 
+
+  public DDF transformUDF(List<String> transformExpressions) throws DDFException {
+    return transformUDF(transformExpressions, null);
+  }
+
+
+  public DDF transformUDF(String transformExpression, List<String> columns) throws DDFException {
+    List<String> transformExpressions = new ArrayList<String>();
+    transformExpressions.add(transformExpression);
+    return mTransformationHandler.transformUDF(transformExpressions, columns);
+  }
 
   public DDF transformUDF(String transformExpression) throws DDFException {
     return transformUDF(transformExpression, null);


### PR DESCRIPTION
Or a single expression. No longer is a string of comma-separated expressions accepted. This is to eliminate bugs caused by splitting expressions containing commas by comma character.