### PR TITLE
Add a custom Spark UDF for converting datetime strings to the standard Hive one

### DIFF
--- a/project/RootBuild.scala
+++ b/project/RootBuild.scala
@@ -206,7 +206,8 @@ object RootBuild extends Build {
       "org.easymock" % "easymock" % "3.1" % "test",
 
       //"edu.berkeley.cs.shark" % "hive-contrib" % "0.11.0-shark" exclude("com.google.protobuf", "protobuf-java") exclude("io.netty", "netty-all") exclude("org.jboss.netty", "netty"),
-      "mysql" % "mysql-connector-java" % "5.1.25"
+      "mysql" % "mysql-connector-java" % "5.1.25",
+      "joda-time" % "joda-time" % "2.8.1"
     ),
 
 

--- a/spark/src/main/java/io/ddf/spark/SparkDDFManager.java
+++ b/spark/src/main/java/io/ddf/spark/SparkDDFManager.java
@@ -6,6 +6,7 @@ import io.ddf.DDF;
 import io.ddf.DDFManager;
 import io.ddf.content.Schema;
 import io.ddf.exception.DDFException;
+import io.ddf.spark.etl.udf.DateParse;
 import io.ddf.spark.util.SparkUtils;
 import io.ddf.spark.util.Utils;
 import org.apache.commons.lang.StringUtils;
@@ -66,6 +67,13 @@ public class SparkDDFManager extends DDFManager {
     mLog.info(">>>> spark.sql.inMemoryColumnarStorage.batchSize= " + batchSize);
     this.mHiveContext.setConf("spark.sql.inMemoryColumnarStorage.compressed", compression);
     this.mHiveContext.setConf("spark.sql.inMemoryColumnarStorage.batchSize", batchSize);
+
+    // register SparkSQL UDFs
+    this.registerUDFs();
+  }
+
+  private void registerUDFs() {
+    DateParse.register(this.mHiveContext);
   }
 
 

--- a/spark/src/main/java/io/ddf/spark/SparkDDFManager.java
+++ b/spark/src/main/java/io/ddf/spark/SparkDDFManager.java
@@ -71,7 +71,7 @@ public class SparkDDFManager extends DDFManager {
     // register SparkSQL UDFs
     this.registerUDFs();
   }
-
+  // TODO: Dynamically load UDFs
   private void registerUDFs() {
     DateParse.register(this.mHiveContext);
   }

--- a/spark/src/main/java/io/ddf/spark/etl/udf/DateParse.java
+++ b/spark/src/main/java/io/ddf/spark/etl/udf/DateParse.java
@@ -6,12 +6,13 @@ import org.apache.spark.sql.api.java.UDF2;
 import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.DataTypes;
 import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
 
 /**
  * A SparkSQL UDF that convert a datetime string in a specific format into a datetime string
- * of format "yyyy-MM-dd HH:mm:ss"
+ * of format "yyyy-MM-dd HH:mm:ss" in UTC time zone
  * <p>
  * Examples:
  * <p>
@@ -35,7 +36,7 @@ public class DateParse {
       try {
         DateTime dt = null;
         if (format.equalsIgnoreCase("iso")) {
-          dt = new DateTime(string);
+          dt = new DateTime(string, DateTimeZone.UTC);
         } else {
           DateTimeFormatter formatter = DateTimeFormat.forPattern(format);
           dt = formatter.parseDateTime(string);

--- a/spark/src/main/java/io/ddf/spark/etl/udf/DateParse.java
+++ b/spark/src/main/java/io/ddf/spark/etl/udf/DateParse.java
@@ -1,0 +1,53 @@
+package io.ddf.spark.etl.udf;
+
+
+import org.apache.spark.sql.SQLContext;
+import org.apache.spark.sql.api.java.UDF2;
+import org.apache.spark.sql.types.DataType;
+import org.apache.spark.sql.types.DataTypes;
+import org.joda.time.DateTime;
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
+
+/**
+ * A SparkSQL UDF that convert a datetime string in a specific format into a datetime string
+ * of format "yyyy-MM-dd HH:mm:ss"
+ * <p>
+ * Examples:
+ * <p>
+ * <ul>
+ *  <li>select date_parse(dt, "yyyy-MM-dd'T'HH:mm:ssZ") from table</li>
+ *  <li>select date_parse(dt, "iso") from table</li>
+ * </ul>
+ *
+ * Created by nhanitvn on 28/07/2015.
+ * @param string the datetime string to convert
+ * @param format a string to specify the datetime string's format. A convenient value is "iso" to just specify that
+ *               the datetime string is of ISO 8601 format
+ * @return a datetime string in new format, null if there is any error.
+ */
+public class DateParse {
+  static String name = "date_parse";
+  static DataType dataTypes = DataTypes.StringType;
+  static UDF2 udf = new UDF2<String, String, String>() {
+    @Override public String call(String string, String format) throws Exception {
+
+      try {
+        DateTime dt = null;
+        if (format.equalsIgnoreCase("iso")) {
+          dt = new DateTime(string);
+        } else {
+          DateTimeFormatter formatter = DateTimeFormat.forPattern(format);
+          dt = formatter.parseDateTime(string);
+        }
+        return dt.toString(DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss"));
+      } catch (Exception e) {
+        return null;
+      }
+    }
+  };
+
+  public static void register(SQLContext sqlContext) {
+    sqlContext.udf().register(name, udf, dataTypes);
+  }
+}

--- a/spark/src/test/java/io/ddf/spark/etl/UDFTest.java
+++ b/spark/src/test/java/io/ddf/spark/etl/UDFTest.java
@@ -1,0 +1,64 @@
+package io.ddf.spark.etl;
+
+
+import io.ddf.DDF;
+import io.ddf.content.SqlResult;
+import io.ddf.exception.DDFException;
+import io.ddf.spark.BaseTest;
+import org.joda.time.DateTime;
+import org.joda.time.format.DateTimeFormat;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+/**
+ * Created by nhanitvn on 28/07/2015.
+ */
+public class UDFTest extends BaseTest {
+  private DDF ddf;
+
+
+  @Before
+  public void setUp() throws Exception {
+    createTableAirlineWithNA();
+
+    ddf = manager.sql2ddf("select * from airline");
+  }
+
+  @Test
+  public void testDateParseNonISO() throws DDFException {
+    DDF ddf2 = ddf.Transform.transformUDF("dt=concat(year,'-',month,'-',dayofmonth,' 00:00:00')");
+    DDF ddf3 = ddf2.sql2ddf("select date_parse(dt, 'yyyy-MM-dd HH:mm:ss') from @this");
+    List<String> rows = ddf3.VIEWS.head(1);
+    //System.out.println(rows.get(0));
+    Assert.assertTrue(rows.get(0).equalsIgnoreCase("2008-01-03 00:00:00"));
+
+    ddf3 = ddf2.sql2ddf("select date_parse('2015-01-22 20:23 +0000', \"yyyy-MM-dd HH:mm Z\") from @this");
+    rows = ddf3.VIEWS.head(1);
+    Assert.assertTrue(rows.get(0).equalsIgnoreCase((DateTimeFormat.forPattern("yyyy-MM-dd HH:mm Z").parseDateTime("2015-01-22 20:23 +0000"))
+        .toString(DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss"))));
+  }
+
+  @Test
+  public void testDateParseISO() throws DDFException {
+    DDF ddf2 = ddf.Transform.transformUDF("dt=concat(year,'-',month,'-',dayofmonth,'T00:00:00+00')");
+    DDF ddf3 = ddf2.sql2ddf("select date_parse(dt, \"yyyy-MM-dd'T'HH:mm:ssZ\") from @this");
+    List<String> rows = ddf3.VIEWS.head(1);
+    Assert.assertTrue(rows.get(0).equalsIgnoreCase((new DateTime("2008-01-03T00:00:00+00")).toString(DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss"))));
+
+    ddf3 = ddf2.sql2ddf("select date_parse(dt, \"iso\") from @this");
+    rows = ddf3.VIEWS.head(1);
+    //System.out.println(rows.get(0));
+    Assert.assertTrue(rows.get(0).equalsIgnoreCase((new DateTime("2008-01-03T00:00:00+00")).toString(DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss"))));
+
+    ddf3 = ddf2.sql2ddf("select date_parse('2015-03-20T15:04:37.617Z', \"iso\") from @this");
+    rows = ddf3.VIEWS.head(1);
+    Assert.assertTrue(rows.get(0).equalsIgnoreCase((new DateTime("2015-03-20T15:04:37.617Z")).toString(DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss"))));
+
+    ddf3 = ddf2.sql2ddf("select date_parse('2015-06-05T01:05:00-0500', \"iso\") from @this");
+    rows = ddf3.VIEWS.head(1);
+    Assert.assertTrue(rows.get(0).equalsIgnoreCase((new DateTime("2015-06-05T01:05:00-0500")).toString(DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss"))));
+  }
+}

--- a/spark/src/test/java/io/ddf/spark/etl/UDFTest.java
+++ b/spark/src/test/java/io/ddf/spark/etl/UDFTest.java
@@ -60,5 +60,11 @@ public class UDFTest extends BaseTest {
     ddf3 = ddf2.sql2ddf("select date_parse('2015-06-05T01:05:00-0500', \"iso\") from @this");
     rows = ddf3.VIEWS.head(1);
     Assert.assertTrue(rows.get(0).equalsIgnoreCase((new DateTime("2015-06-05T01:05:00-0500")).toString(DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss"))));
+
+    // Make sure the output of data_parse is consumable to other UDFs
+    ddf3 = ddf2.sql2ddf("select hour(date_parse('2015-06-05T01:05:00-0500', \"iso\")) from @this");
+    rows = ddf3.VIEWS.head(1);
+    //System.out.println(rows.get(0));
+    Assert.assertTrue(rows.get(0).equalsIgnoreCase((new DateTime("2015-06-05T01:05:00-0500")).hourOfDay().toString()));
   }
 }

--- a/spark/src/test/java/io/ddf/spark/etl/UDFTest.java
+++ b/spark/src/test/java/io/ddf/spark/etl/UDFTest.java
@@ -6,6 +6,7 @@ import io.ddf.content.SqlResult;
 import io.ddf.exception.DDFException;
 import io.ddf.spark.BaseTest;
 import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import org.joda.time.format.DateTimeFormat;
 import org.junit.Assert;
 import org.junit.Before;
@@ -50,21 +51,27 @@ public class UDFTest extends BaseTest {
 
     ddf3 = ddf2.sql2ddf("select date_parse(dt, \"iso\") from @this");
     rows = ddf3.VIEWS.head(1);
-    //System.out.println(rows.get(0));
-    Assert.assertTrue(rows.get(0).equalsIgnoreCase((new DateTime("2008-01-03T00:00:00+00")).toString(DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss"))));
+    System.out.println(rows.get(0));
+    Assert.assertTrue(rows.get(0).equalsIgnoreCase((new DateTime("2008-01-03T00:00:00+00", DateTimeZone.UTC))
+        .toString(DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss"))));
 
     ddf3 = ddf2.sql2ddf("select date_parse('2015-03-20T15:04:37.617Z', \"iso\") from @this");
     rows = ddf3.VIEWS.head(1);
-    Assert.assertTrue(rows.get(0).equalsIgnoreCase((new DateTime("2015-03-20T15:04:37.617Z")).toString(DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss"))));
+    Assert.assertTrue(rows.get(0).equalsIgnoreCase((new DateTime("2015-03-20T15:04:37.617Z", DateTimeZone.UTC))
+        .toString(DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss"))));
 
     ddf3 = ddf2.sql2ddf("select date_parse('2015-06-05T01:05:00-0500', \"iso\") from @this");
     rows = ddf3.VIEWS.head(1);
-    Assert.assertTrue(rows.get(0).equalsIgnoreCase((new DateTime("2015-06-05T01:05:00-0500")).toString(DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss"))));
+    System.out.println((new DateTime("2015-06-05T01:05:00-0500", DateTimeZone.UTC))
+        .toString(DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss")));
+    Assert.assertTrue(rows.get(0).equalsIgnoreCase((new DateTime("2015-06-05T01:05:00-0500", DateTimeZone.UTC))
+        .toString(DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss"))));
 
     // Make sure the output of data_parse is consumable to other UDFs
     ddf3 = ddf2.sql2ddf("select hour(date_parse('2015-06-05T01:05:00-0500', \"iso\")) from @this");
     rows = ddf3.VIEWS.head(1);
     //System.out.println(rows.get(0));
-    Assert.assertTrue(rows.get(0).equalsIgnoreCase((new DateTime("2015-06-05T01:05:00-0500")).hourOfDay().toString()));
+    //System.out.println((new DateTime("2015-06-05T01:05:00-0500", DateTimeZone.UTC)).hourOfDay().get());
+    Assert.assertTrue(Integer.parseInt(rows.get(0))== (new DateTime("2015-06-05T01:05:00-0500", DateTimeZone.UTC)).hourOfDay().get());
   }
 }


### PR DESCRIPTION
which is yyyy-MM-dd HH:mm:ss using Joda library
The API signature is date_parse(String datetime_string, String format)