### PR TITLE
Add more standalone UDFs to extract date/time information from unix_timestamp or ISO datetime columns/strings

### DIFF
--- a/spark/src/main/java/io/ddf/spark/SparkDDFManager.java
+++ b/spark/src/main/java/io/ddf/spark/SparkDDFManager.java
@@ -8,6 +8,9 @@ import io.ddf.content.Schema;
 import io.ddf.exception.DDFException;
 import io.ddf.spark.etl.udf.DateParse;
 import io.ddf.spark.etl.udf.DateTimeExtract;
+import io.ddf.spark.etl.udf.DayOfWeek;
+import io.ddf.spark.etl.udf.Hour;
+import io.ddf.spark.etl.udf.Year;
 import io.ddf.spark.util.SparkUtils;
 import io.ddf.spark.util.Utils;
 import org.apache.commons.lang.StringUtils;
@@ -76,6 +79,9 @@ public class SparkDDFManager extends DDFManager {
   private void registerUDFs() {
     DateParse.register(this.mHiveContext);
     DateTimeExtract.register(this.mHiveContext);
+    DayOfWeek.register(this.mHiveContext);
+    Hour.register(this.mHiveContext);
+    Year.register(this.mHiveContext);
   }
 
 

--- a/spark/src/main/java/io/ddf/spark/SparkDDFManager.java
+++ b/spark/src/main/java/io/ddf/spark/SparkDDFManager.java
@@ -6,11 +6,7 @@ import io.ddf.DDF;
 import io.ddf.DDFManager;
 import io.ddf.content.Schema;
 import io.ddf.exception.DDFException;
-import io.ddf.spark.etl.udf.DateParse;
-import io.ddf.spark.etl.udf.DateTimeExtract;
-import io.ddf.spark.etl.udf.DayOfWeek;
-import io.ddf.spark.etl.udf.Hour;
-import io.ddf.spark.etl.udf.Year;
+import io.ddf.spark.etl.udf.*;
 import io.ddf.spark.util.SparkUtils;
 import io.ddf.spark.util.Utils;
 import org.apache.commons.lang.StringUtils;
@@ -79,9 +75,17 @@ public class SparkDDFManager extends DDFManager {
   private void registerUDFs() {
     DateParse.register(this.mHiveContext);
     DateTimeExtract.register(this.mHiveContext);
-    DayOfWeek.register(this.mHiveContext);
-    Hour.register(this.mHiveContext);
     Year.register(this.mHiveContext);
+    Month.register(this.mHiveContext);
+    WeekYear.register(this.mHiveContext);
+    WeekOfWeekYear.register(this.mHiveContext);
+    DayOfWeek.register(this.mHiveContext);
+    Day.register(this.mHiveContext);
+    DayOfYear.register(this.mHiveContext);
+    Hour.register(this.mHiveContext);
+    Minute.register(this.mHiveContext);
+    Second.register(this.mHiveContext);
+    Millisecond.register(this.mHiveContext);
   }
 
 

--- a/spark/src/main/java/io/ddf/spark/etl/udf/DateTimeExtract.java
+++ b/spark/src/main/java/io/ddf/spark/etl/udf/DateTimeExtract.java
@@ -12,8 +12,8 @@ import org.joda.time.DateTimeZone;
 /**
  * A SparkSQL UDF that extract date/time field from a unixtimestamp or an ISO8601 datetime string.
  * In case of an ISO datetime string with timezone, the output will be a
- * localized value wrt the corresponding timezone.
- * Support fields: year, month, day, dayofweek, dayofyear, hour, minute, second, millisecond
+ * local datetime at UTC timezone.
+ * Support fields: year, month, weekyear, weekofyear, day, dayofweek, dayofyear, hour, minute, second, millisecond
  * Created by nhanitvn on 30/07/2015.
  */
 public class DateTimeExtract {

--- a/spark/src/main/java/io/ddf/spark/etl/udf/DateTimeExtract.java
+++ b/spark/src/main/java/io/ddf/spark/etl/udf/DateTimeExtract.java
@@ -20,38 +20,35 @@ public class DateTimeExtract {
 
   static UDF2 udf = new UDF2<Object, String, Integer>() {
     @Override public Integer call(Object object, String field) throws Exception {
-      DateTime dt = null;
-      if (object instanceof Integer) {
-        // Unix timestamp
-        dt = new DateTime((Integer) object * 1000L).withZone(DateTimeZone.UTC);
-      } else {
-        dt = Utils.toDateTimeObject((String) object);
-      }
-
-      Integer value = null;
+      DateTime dt = Utils.toDateTimeObject((String) object);
+      
       if (dt != null) {
         if (field.equalsIgnoreCase("year")) {
-          value = new Integer(dt.getYear());
+          return new Integer(dt.getYear());
         } else if (field.equalsIgnoreCase("month")) {
-          value = new Integer(dt.getMonthOfYear());
+          return new Integer(dt.getMonthOfYear());
+        } else if (field.equalsIgnoreCase("weekyear")) {
+          return new Integer(dt.getWeekyear());
+        } else if (field.equalsIgnoreCase("weekofweekyear")) {
+          return new Integer(dt.getWeekOfWeekyear());
         } else if (field.equalsIgnoreCase("day")) {
-          value = new Integer(dt.getDayOfMonth());
+          return new Integer(dt.getDayOfMonth());
         } else if (field.equalsIgnoreCase("dayofweek")) {
-          value = new Integer(dt.getDayOfWeek());
+          return new Integer(dt.getDayOfWeek());
         } else if (field.equalsIgnoreCase("dayofyear")) {
-          value = new Integer(dt.getDayOfYear());
+          return new Integer(dt.getDayOfYear());
         } else if (field.equalsIgnoreCase("hour")) {
-          value = new Integer(dt.getHourOfDay());
+          return new Integer(dt.getHourOfDay());
         } else if (field.equalsIgnoreCase("minute")) {
-          value = new Integer(dt.getMinuteOfHour());
+          return new Integer(dt.getMinuteOfHour());
         } else if (field.equalsIgnoreCase("second")) {
-          value = new Integer(dt.getSecondOfMinute());
+          return new Integer(dt.getSecondOfMinute());
         } else if (field.equalsIgnoreCase("millisecond")) {
-          value = new Integer(dt.getMillisOfSecond());
+          return new Integer(dt.getMillisOfSecond());
         }
 
       }
-      return value;
+      return null;
     }
   };
 

--- a/spark/src/main/java/io/ddf/spark/etl/udf/Day.java
+++ b/spark/src/main/java/io/ddf/spark/etl/udf/Day.java
@@ -8,6 +8,10 @@ import org.apache.spark.sql.types.DataTypes;
 import org.joda.time.DateTime;
 
 /**
+ * A SparkSQL UDF to extract day of month information from a unixtimestamp
+ * or an ISO8601 datetime string.
+ * In case of an ISO datetime string with timezone, the output will be a
+ * local value at UTC timezone.
  * Created by nhanitvn on 10/08/2015.
  */
 public class Day {

--- a/spark/src/main/java/io/ddf/spark/etl/udf/Day.java
+++ b/spark/src/main/java/io/ddf/spark/etl/udf/Day.java
@@ -1,0 +1,29 @@
+package io.ddf.spark.etl.udf;
+
+
+import io.ddf.spark.util.Utils;
+import org.apache.spark.sql.SQLContext;
+import org.apache.spark.sql.api.java.UDF1;
+import org.apache.spark.sql.types.DataTypes;
+import org.joda.time.DateTime;
+
+/**
+ * Created by nhanitvn on 10/08/2015.
+ */
+public class Day {
+  static UDF1 udf = new UDF1<Object, Integer>() {
+    @Override public Integer call(Object object) throws Exception {
+      DateTime dt = Utils.toDateTimeObject((String) object);
+
+      if (dt != null) {
+        return Integer.parseInt(dt.dayOfMonth().getAsString());
+      } else {
+        return null;
+      }
+    }
+  };
+
+  public static void register(SQLContext sqlContext) {
+    sqlContext.udf().register("day", udf, DataTypes.IntegerType);
+  }
+}

--- a/spark/src/main/java/io/ddf/spark/etl/udf/DayOfWeek.java
+++ b/spark/src/main/java/io/ddf/spark/etl/udf/DayOfWeek.java
@@ -1,0 +1,38 @@
+package io.ddf.spark.etl.udf;
+
+
+import io.ddf.spark.util.Utils;
+import org.apache.spark.sql.SQLContext;
+import org.apache.spark.sql.api.java.UDF2;
+import org.apache.spark.sql.types.DataTypes;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
+
+/**
+ * Created by nhanitvn on 08/08/2015.
+ */
+public class DayOfWeek {
+  static UDF2 udf = new UDF2<Object, String, String>() {
+    @Override public String call(Object object, String format) throws Exception {
+
+      DateTime dt = Utils.toDateTimeObject((String) object);
+
+      if (dt != null) {
+        if (format.equalsIgnoreCase("number")) {
+          return "" + dt.getDayOfWeek();
+        } else if (format.equalsIgnoreCase("text")) {
+          return dt.dayOfWeek().getAsText();
+        } else if (format.equalsIgnoreCase("shorttext")) {
+          return dt.dayOfWeek().getAsShortText();
+        }
+      }
+      return null;
+    }
+  };
+
+  public static void register(SQLContext sqlContext) {
+    sqlContext.udf().register("dayofweek", udf, DataTypes.StringType);
+  }
+}

--- a/spark/src/main/java/io/ddf/spark/etl/udf/DayOfWeek.java
+++ b/spark/src/main/java/io/ddf/spark/etl/udf/DayOfWeek.java
@@ -11,6 +11,13 @@ import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
 
 /**
+ * A SparkSQL UDF to extract day of week information from a unixtimestamp
+ * or an ISO8601 datetime string.
+ * In case of an ISO datetime string with timezone, the output will be a
+ * local value at UTC timezone.
+ * @param format: either "number" or "text" or "shorttext" to return a number (1-7)
+ *              or a text (Monday - Sunday)
+ *              or a short text (Mon - Sun)
  * Created by nhanitvn on 08/08/2015.
  */
 public class DayOfWeek {

--- a/spark/src/main/java/io/ddf/spark/etl/udf/DayOfYear.java
+++ b/spark/src/main/java/io/ddf/spark/etl/udf/DayOfYear.java
@@ -1,0 +1,29 @@
+package io.ddf.spark.etl.udf;
+
+
+import io.ddf.spark.util.Utils;
+import org.apache.spark.sql.SQLContext;
+import org.apache.spark.sql.api.java.UDF1;
+import org.apache.spark.sql.types.DataTypes;
+import org.joda.time.DateTime;
+
+/**
+ * Created by nhanitvn on 10/08/2015.
+ */
+public class DayOfYear {
+  static UDF1 udf = new UDF1<Object, Integer>() {
+    @Override public Integer call(Object object) throws Exception {
+      DateTime dt = Utils.toDateTimeObject((String) object);
+
+      if (dt != null) {
+        return Integer.parseInt(dt.dayOfYear().getAsString());
+      } else {
+        return null;
+      }
+    }
+  };
+
+  public static void register(SQLContext sqlContext) {
+    sqlContext.udf().register("dayofyear", udf, DataTypes.IntegerType);
+  }
+}

--- a/spark/src/main/java/io/ddf/spark/etl/udf/DayOfYear.java
+++ b/spark/src/main/java/io/ddf/spark/etl/udf/DayOfYear.java
@@ -8,6 +8,10 @@ import org.apache.spark.sql.types.DataTypes;
 import org.joda.time.DateTime;
 
 /**
+ * A SparkSQL UDF to extract day of year information from a unixtimestamp
+ * or an ISO8601 datetime string.
+ * In case of an ISO datetime string with timezone, the output will be a
+ * local value at UTC timezone.
  * Created by nhanitvn on 10/08/2015.
  */
 public class DayOfYear {

--- a/spark/src/main/java/io/ddf/spark/etl/udf/Hour.java
+++ b/spark/src/main/java/io/ddf/spark/etl/udf/Hour.java
@@ -11,6 +11,10 @@ import org.joda.time.DateTime;
 import java.util.regex.Pattern;
 
 /**
+ * A SparkSQL UDF to extract hour information from a unixtimestamp
+ * or an ISO8601 datetime string.
+ * In case of an ISO datetime string with timezone, the output will be a
+ * local value at UTC timezone.
  * Created by nhanitvn on 30/07/2015.
  */
 public class Hour {

--- a/spark/src/main/java/io/ddf/spark/etl/udf/Hour.java
+++ b/spark/src/main/java/io/ddf/spark/etl/udf/Hour.java
@@ -1,0 +1,33 @@
+package io.ddf.spark.etl.udf;
+
+
+import io.ddf.spark.util.Utils;
+import org.apache.spark.sql.SQLContext;
+import org.apache.spark.sql.api.java.UDF1;
+import org.apache.spark.sql.types.DataType;
+import org.apache.spark.sql.types.DataTypes;
+import org.joda.time.DateTime;
+
+import java.util.regex.Pattern;
+
+/**
+ * Created by nhanitvn on 30/07/2015.
+ */
+public class Hour {
+
+  static UDF1 udf = new UDF1<Object, Integer>() {
+    @Override public Integer call(Object object) throws Exception {
+      DateTime dt = Utils.toDateTimeObject((String) object);
+
+      if (dt != null) {
+        return Integer.parseInt(dt.hourOfDay().getAsString());
+      } else {
+        return null;
+      }
+    }
+  };
+
+  public static void register(SQLContext sqlContext) {
+    sqlContext.udf().register("hour", udf, DataTypes.IntegerType);
+  }
+}

--- a/spark/src/main/java/io/ddf/spark/etl/udf/Millisecond.java
+++ b/spark/src/main/java/io/ddf/spark/etl/udf/Millisecond.java
@@ -8,6 +8,10 @@ import org.apache.spark.sql.types.DataTypes;
 import org.joda.time.DateTime;
 
 /**
+ * A SparkSQL UDF to extract millisecond information from a unixtimestamp
+ * or an ISO8601 datetime string.
+ * In case of an ISO datetime string with timezone, the output will be a
+ * local value at UTC timezone.
  * Created by nhanitvn on 10/08/2015.
  */
 public class Millisecond {

--- a/spark/src/main/java/io/ddf/spark/etl/udf/Millisecond.java
+++ b/spark/src/main/java/io/ddf/spark/etl/udf/Millisecond.java
@@ -1,0 +1,29 @@
+package io.ddf.spark.etl.udf;
+
+
+import io.ddf.spark.util.Utils;
+import org.apache.spark.sql.SQLContext;
+import org.apache.spark.sql.api.java.UDF1;
+import org.apache.spark.sql.types.DataTypes;
+import org.joda.time.DateTime;
+
+/**
+ * Created by nhanitvn on 10/08/2015.
+ */
+public class Millisecond {
+  static UDF1 udf = new UDF1<Object, Integer>() {
+    @Override public Integer call(Object object) throws Exception {
+      DateTime dt = Utils.toDateTimeObject((String) object);
+
+      if (dt != null) {
+        return Integer.parseInt(dt.millisOfSecond().getAsString());
+      } else {
+        return null;
+      }
+    }
+  };
+
+  public static void register(SQLContext sqlContext) {
+    sqlContext.udf().register("millisecond", udf, DataTypes.IntegerType);
+  }
+}

--- a/spark/src/main/java/io/ddf/spark/etl/udf/Minute.java
+++ b/spark/src/main/java/io/ddf/spark/etl/udf/Minute.java
@@ -8,6 +8,10 @@ import org.apache.spark.sql.types.DataTypes;
 import org.joda.time.DateTime;
 
 /**
+ * A SparkSQL UDF to extract minute information from a unixtimestamp
+ * or an ISO8601 datetime string.
+ * In case of an ISO datetime string with timezone, the output will be a
+ * local value at UTC timezone.
  * Created by nhanitvn on 10/08/2015.
  */
 public class Minute {

--- a/spark/src/main/java/io/ddf/spark/etl/udf/Minute.java
+++ b/spark/src/main/java/io/ddf/spark/etl/udf/Minute.java
@@ -1,0 +1,29 @@
+package io.ddf.spark.etl.udf;
+
+
+import io.ddf.spark.util.Utils;
+import org.apache.spark.sql.SQLContext;
+import org.apache.spark.sql.api.java.UDF1;
+import org.apache.spark.sql.types.DataTypes;
+import org.joda.time.DateTime;
+
+/**
+ * Created by nhanitvn on 10/08/2015.
+ */
+public class Minute {
+  static UDF1 udf = new UDF1<Object, Integer>() {
+    @Override public Integer call(Object object) throws Exception {
+      DateTime dt = Utils.toDateTimeObject((String) object);
+
+      if (dt != null) {
+        return Integer.parseInt(dt.minuteOfHour().getAsString());
+      } else {
+        return null;
+      }
+    }
+  };
+
+  public static void register(SQLContext sqlContext) {
+    sqlContext.udf().register("minute", udf, DataTypes.IntegerType);
+  }
+}

--- a/spark/src/main/java/io/ddf/spark/etl/udf/Month.java
+++ b/spark/src/main/java/io/ddf/spark/etl/udf/Month.java
@@ -8,6 +8,13 @@ import org.apache.spark.sql.types.DataTypes;
 import org.joda.time.DateTime;
 
 /**
+ * A SparkSQL UDF to extract month information from a unixtimestamp
+ * or an ISO8601 datetime string.
+ * In case of an ISO datetime string with timezone, the output will be a
+ * local value at UTC timezone.
+ * @param format: either "number" or "text" or "shorttext" to return a number (1-12)
+ *              or a text (January - December)
+ *              or a short text (Jan - Dec)
  * Created by nhanitvn on 10/08/2015.
  */
 public class Month {

--- a/spark/src/main/java/io/ddf/spark/etl/udf/Month.java
+++ b/spark/src/main/java/io/ddf/spark/etl/udf/Month.java
@@ -1,0 +1,35 @@
+package io.ddf.spark.etl.udf;
+
+
+import io.ddf.spark.util.Utils;
+import org.apache.spark.sql.SQLContext;
+import org.apache.spark.sql.api.java.UDF2;
+import org.apache.spark.sql.types.DataTypes;
+import org.joda.time.DateTime;
+
+/**
+ * Created by nhanitvn on 10/08/2015.
+ */
+public class Month {
+  static UDF2 udf = new UDF2<Object, String, String>() {
+    @Override public String call(Object object, String format) throws Exception {
+
+      DateTime dt = Utils.toDateTimeObject((String) object);
+
+      if (dt != null) {
+        if (format.equalsIgnoreCase("number")) {
+          return "" + dt.getMonthOfYear();
+        } else if (format.equalsIgnoreCase("text")) {
+          return dt.monthOfYear().getAsText();
+        } else if (format.equalsIgnoreCase("shorttext")) {
+          return dt.monthOfYear().getAsShortText();
+        }
+      }
+      return null;
+    }
+  };
+
+  public static void register(SQLContext sqlContext) {
+    sqlContext.udf().register("month", udf, DataTypes.StringType);
+  }
+}

--- a/spark/src/main/java/io/ddf/spark/etl/udf/Second.java
+++ b/spark/src/main/java/io/ddf/spark/etl/udf/Second.java
@@ -1,0 +1,29 @@
+package io.ddf.spark.etl.udf;
+
+
+import io.ddf.spark.util.Utils;
+import org.apache.spark.sql.SQLContext;
+import org.apache.spark.sql.api.java.UDF1;
+import org.apache.spark.sql.types.DataTypes;
+import org.joda.time.DateTime;
+
+/**
+ * Created by nhanitvn on 10/08/2015.
+ */
+public class Second {
+  static UDF1 udf = new UDF1<Object, Integer>() {
+    @Override public Integer call(Object object) throws Exception {
+      DateTime dt = Utils.toDateTimeObject((String) object);
+
+      if (dt != null) {
+        return Integer.parseInt(dt.secondOfMinute().getAsString());
+      } else {
+        return null;
+      }
+    }
+  };
+
+  public static void register(SQLContext sqlContext) {
+    sqlContext.udf().register("second", udf, DataTypes.IntegerType);
+  }
+}

--- a/spark/src/main/java/io/ddf/spark/etl/udf/Second.java
+++ b/spark/src/main/java/io/ddf/spark/etl/udf/Second.java
@@ -8,6 +8,10 @@ import org.apache.spark.sql.types.DataTypes;
 import org.joda.time.DateTime;
 
 /**
+ * A SparkSQL UDF to extract second information from a unixtimestamp
+ * or an ISO8601 datetime string.
+ * In case of an ISO datetime string with timezone, the output will be a
+ * local value at UTC timezone.
  * Created by nhanitvn on 10/08/2015.
  */
 public class Second {

--- a/spark/src/main/java/io/ddf/spark/etl/udf/WeekOfWeekYear.java
+++ b/spark/src/main/java/io/ddf/spark/etl/udf/WeekOfWeekYear.java
@@ -8,6 +8,14 @@ import org.apache.spark.sql.types.DataTypes;
 import org.joda.time.DateTime;
 
 /**
+ * A SparkSQL UDF to extract week of week year information from a unixtimestamp
+ * or an ISO8601 datetime string.
+ * In case of an ISO datetime string with timezone, the output will be a
+ * local value at UTC timezone.
+ * This function is normally used together with weekyear UDF
+ * Example: weekyear('2015-01-22 20:23 +0000') = 2015
+ *          weekofweekyear('2015-01-22 20:23 +0000') = 4
+ *
  * Created by nhanitvn on 10/08/2015.
  */
 public class WeekOfWeekYear {

--- a/spark/src/main/java/io/ddf/spark/etl/udf/WeekOfWeekYear.java
+++ b/spark/src/main/java/io/ddf/spark/etl/udf/WeekOfWeekYear.java
@@ -1,0 +1,29 @@
+package io.ddf.spark.etl.udf;
+
+
+import io.ddf.spark.util.Utils;
+import org.apache.spark.sql.SQLContext;
+import org.apache.spark.sql.api.java.UDF1;
+import org.apache.spark.sql.types.DataTypes;
+import org.joda.time.DateTime;
+
+/**
+ * Created by nhanitvn on 10/08/2015.
+ */
+public class WeekOfWeekYear {
+  static UDF1 udf = new UDF1<Object, Integer>() {
+    @Override public Integer call(Object object) throws Exception {
+      DateTime dt = Utils.toDateTimeObject((String) object);
+
+      if (dt != null) {
+        return Integer.parseInt(dt.weekOfWeekyear().getAsString());
+      } else {
+        return null;
+      }
+    }
+  };
+
+  public static void register(SQLContext sqlContext) {
+    sqlContext.udf().register("weekofweekyear", udf, DataTypes.IntegerType);
+  }
+}

--- a/spark/src/main/java/io/ddf/spark/etl/udf/WeekYear.java
+++ b/spark/src/main/java/io/ddf/spark/etl/udf/WeekYear.java
@@ -8,6 +8,12 @@ import org.apache.spark.sql.types.DataTypes;
 import org.joda.time.DateTime;
 
 /**
+ * A SparkSQL UDF to extract week year information from a unixtimestamp
+ * or an ISO8601 datetime string. In case of an ISO datetime string with timezone,
+ * the output will be a local value at UTC timezone.
+ * This function is normally used together with weekofweekyear UDF
+ * Example: weekyear('2015-01-22 20:23 +0000') = 2015
+ *          weekofweekyear('2015-01-22 20:23 +0000') = 4
  * Created by nhanitvn on 10/08/2015.
  */
 public class WeekYear {

--- a/spark/src/main/java/io/ddf/spark/etl/udf/WeekYear.java
+++ b/spark/src/main/java/io/ddf/spark/etl/udf/WeekYear.java
@@ -1,0 +1,29 @@
+package io.ddf.spark.etl.udf;
+
+
+import io.ddf.spark.util.Utils;
+import org.apache.spark.sql.SQLContext;
+import org.apache.spark.sql.api.java.UDF1;
+import org.apache.spark.sql.types.DataTypes;
+import org.joda.time.DateTime;
+
+/**
+ * Created by nhanitvn on 10/08/2015.
+ */
+public class WeekYear {
+  static UDF1 udf = new UDF1<Object, Integer>() {
+    @Override public Integer call(Object object) throws Exception {
+      DateTime dt = Utils.toDateTimeObject((String) object);
+
+      if (dt != null) {
+        return Integer.parseInt(dt.weekyear().getAsString());
+      } else {
+        return null;
+      }
+    }
+  };
+
+  public static void register(SQLContext sqlContext) {
+    sqlContext.udf().register("weekyear", udf, DataTypes.IntegerType);
+  }
+}

--- a/spark/src/main/java/io/ddf/spark/etl/udf/Year.java
+++ b/spark/src/main/java/io/ddf/spark/etl/udf/Year.java
@@ -1,0 +1,30 @@
+package io.ddf.spark.etl.udf;
+
+
+import io.ddf.spark.util.Utils;
+import org.apache.spark.sql.SQLContext;
+import org.apache.spark.sql.api.java.UDF1;
+import org.apache.spark.sql.types.DataTypes;
+import org.joda.time.DateTime;
+
+/**
+ * Created by nhanitvn on 30/07/2015.
+ */
+public class Year {
+
+  static UDF1 udf = new UDF1<Object, Integer>() {
+    @Override public Integer call(Object object) throws Exception {
+      DateTime dt = Utils.toDateTimeObject((String) object);
+
+      if (dt != null) {
+        return Integer.parseInt(dt.year().getAsString());
+      } else {
+        return null;
+      }
+    }
+  };
+
+  public static void register(SQLContext sqlContext) {
+    sqlContext.udf().register("year", udf, DataTypes.IntegerType);
+  }
+}

--- a/spark/src/main/java/io/ddf/spark/etl/udf/Year.java
+++ b/spark/src/main/java/io/ddf/spark/etl/udf/Year.java
@@ -8,6 +8,10 @@ import org.apache.spark.sql.types.DataTypes;
 import org.joda.time.DateTime;
 
 /**
+ * A SparkSQL UDF to extract year information from a unixtimestamp
+ * or an ISO8601 datetime string.
+ * In case of an ISO datetime string with timezone, the output will be a
+ * local value at UTC timezone.
  * Created by nhanitvn on 30/07/2015.
  */
 public class Year {

--- a/spark/src/main/java/io/ddf/spark/util/Utils.java
+++ b/spark/src/main/java/io/ddf/spark/util/Utils.java
@@ -2,6 +2,7 @@ package io.ddf.spark.util;
 
 
 import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
 
@@ -49,46 +50,53 @@ public class Utils {
           + "(?<timezone>Z|\\s?[+-](?:2[0-3]|[01][0-9])(:?[0-5][0-9])?)?)?)?)?$"
   );
 
-  public static DateTime toDateTimeObject(String string) {
-    Matcher matcher= isoPattern.matcher(string);
-    if (matcher.matches()) {
-      String year = matcher.group("year");
-      String month = matcher.group("month");
-      String day = matcher.group("day");
-      String sep = matcher.group("sep");
-      String hour = matcher.group("hour");
-      String minute = matcher.group("minute");
-      String second = matcher.group("second");
-      String ms = matcher.group("ms");
-      String timezone = matcher.group("timezone");
+  public static DateTime toDateTimeObject(Object object) {
+    if (object instanceof Integer) {
+      // Unix timestamp
+      return new DateTime((Integer) object * 1000L).withZone(DateTimeZone.UTC);
+    } else if (object instanceof String) {
 
-      StringBuilder sb = new StringBuilder();
-      sb.append(year);
-      sb.append(month != null ? ("-" + month) : "");
-      sb.append(day != null ? ("-" + day) : "");
-      sb.append(sep != null ? sep : "");
-      sb.append(hour != null ? hour : "");
-      sb.append(minute != null ? (minute) : "");
-      sb.append(second != null ? (second) : "");
-      sb.append(ms != null ? (ms) : "");
-      sb.append(timezone != null ? timezone : "");
+      Matcher matcher = isoPattern.matcher((String)object);
+      if (matcher.matches()) {
+        String year = matcher.group("year");
+        String month = matcher.group("month");
+        String day = matcher.group("day");
+        String sep = matcher.group("sep");
+        String hour = matcher.group("hour");
+        String minute = matcher.group("minute");
+        String second = matcher.group("second");
+        String ms = matcher.group("ms");
+        String timezone = matcher.group("timezone");
 
-      StringBuilder sb2 = new StringBuilder();
-      sb2.append("yyyy");
-      sb2.append(month != null ? ("-" + "MM") : "");
-      sb2.append(day != null ? ("-" + "dd") : "");
-      sb2.append(sep != null ? sep.equalsIgnoreCase("T") ? "'T'" : sep : "");
-      sb2.append(hour != null ? "HH" : "");
-      sb2.append(minute != null ? (":" + "mm") : "");
-      sb2.append(second != null ? (":" + "ss") : "");
-      sb2.append(ms != null ? ("." + "SSS") : "");
-      sb2.append(timezone != null ? timezone.startsWith(" ") ? " Z" : "Z" : "");
+        StringBuilder sb = new StringBuilder();
+        sb.append(year);
+        sb.append(month != null ? ("-" + month) : "");
+        sb.append(day != null ? ("-" + day) : "");
+        sb.append(sep != null ? sep : "");
+        sb.append(hour != null ? hour : "");
+        sb.append(minute != null ? (minute) : "");
+        sb.append(second != null ? (second) : "");
+        sb.append(ms != null ? (ms) : "");
+        sb.append(timezone != null ? timezone : "");
 
-      DateTimeFormatter formatter = DateTimeFormat.forPattern(sb2.toString()).withZoneUTC();
-      return formatter.parseDateTime(sb.toString());
-    } else {
-      return null;
+        StringBuilder sb2 = new StringBuilder();
+        sb2.append("yyyy");
+        sb2.append(month != null ? ("-" + "MM") : "");
+        sb2.append(day != null ? ("-" + "dd") : "");
+        sb2.append(sep != null ? sep.equalsIgnoreCase("T") ? "'T'" : sep : "");
+        sb2.append(hour != null ? "HH" : "");
+        sb2.append(minute != null ? (":" + "mm") : "");
+        sb2.append(second != null ? (":" + "ss") : "");
+        sb2.append(ms != null ? ("." + "SSS") : "");
+        sb2.append(timezone != null ? timezone.startsWith(" ") ? " Z" : "Z" : "");
+
+        DateTimeFormatter formatter = DateTimeFormat.forPattern(sb2.toString()).withZoneUTC();
+        return formatter.parseDateTime(sb.toString());
+      } else {
+        return null;
+      }
     }
+    return null;
   }
 }
 

--- a/spark/src/test/java/io/ddf/spark/etl/UDFTest.java
+++ b/spark/src/test/java/io/ddf/spark/etl/UDFTest.java
@@ -136,6 +136,11 @@ public class UDFTest extends BaseTest {
     System.out.println(rows.get(0));
     Assert.assertTrue(Integer.parseInt(rows.get(0))== 4);
 
+    ddf3 = ddf.sql2ddf("select extract('2015-01-22 20:23 +0000', 'dayofyear') from @this");
+    rows = ddf3.VIEWS.head(1);
+    System.out.println(rows.get(0));
+    Assert.assertTrue(Integer.parseInt(rows.get(0))== 22);
+
     ddf3 = ddf.sql2ddf("select extract('2015-01-22 20:23 +0000', 'minute') from @this");
     rows = ddf3.VIEWS.head(1);
     System.out.println(rows.get(0));
@@ -160,6 +165,31 @@ public class UDFTest extends BaseTest {
     System.out.println(rows.get(0));
     Assert.assertTrue(Integer.parseInt(rows.get(0)) == 2015);
 
+    ddf3 = ddf.sql2ddf("select month('2015-01-22 20:23 +0000', 'number') from @this");
+    rows = ddf3.VIEWS.head(1);
+    System.out.println(rows.get(0));
+    Assert.assertTrue(rows.get(0).equalsIgnoreCase("1"));
+
+    ddf3 = ddf.sql2ddf("select month('2015-01-22 20:23 +0000', 'text') from @this");
+    rows = ddf3.VIEWS.head(1);
+    System.out.println(rows.get(0));
+    Assert.assertTrue(rows.get(0).equalsIgnoreCase("January"));
+
+    ddf3 = ddf.sql2ddf("select month('2015-01-22 20:23 +0000', 'shorttext') from @this");
+    rows = ddf3.VIEWS.head(1);
+    System.out.println(rows.get(0));
+    Assert.assertTrue(rows.get(0).equalsIgnoreCase("Jan"));
+
+    ddf3 = ddf.sql2ddf("select weekyear('2015-01-22 20:23 +0000') from @this");
+    rows = ddf3.VIEWS.head(1);
+    System.out.println(rows.get(0));
+    Assert.assertTrue(Integer.parseInt(rows.get(0)) == 2015);
+
+    ddf3 = ddf.sql2ddf("select weekofweekyear('2015-01-22 20:23 +0000') from @this");
+    rows = ddf3.VIEWS.head(1);
+    System.out.println(rows.get(0));
+    Assert.assertTrue(Integer.parseInt(rows.get(0)) == 4);
+
     ddf3 = ddf.sql2ddf("select dayofweek('2015-01-22 20:23 +0000', 'number') from @this");
     rows = ddf3.VIEWS.head(1);
     System.out.println(rows.get(0));
@@ -175,10 +205,30 @@ public class UDFTest extends BaseTest {
     System.out.println(rows.get(0));
     Assert.assertTrue(rows.get(0).equalsIgnoreCase("Thu"));
 
+    ddf3 = ddf.sql2ddf("select dayofyear('2015-01-22 20:23 +0000') from @this");
+    rows = ddf3.VIEWS.head(1);
+    System.out.println(rows.get(0));
+    Assert.assertTrue(Integer.parseInt(rows.get(0)) == 22);
+
     ddf3 = ddf.sql2ddf("select hour('2015-01-22 20:23 +0000') from @this");
     rows = ddf3.VIEWS.head(1);
     System.out.println(rows.get(0));
     Assert.assertTrue(Integer.parseInt(rows.get(0)) == 20);
+
+    ddf3 = ddf.sql2ddf("select minute('2015-01-22 20:23 +0000') from @this");
+    rows = ddf3.VIEWS.head(1);
+    System.out.println(rows.get(0));
+    Assert.assertTrue(Integer.parseInt(rows.get(0)) == 23);
+
+    ddf3 = ddf.sql2ddf("select second('2015-01-22 20:23 +0000') from @this");
+    rows = ddf3.VIEWS.head(1);
+    System.out.println(rows.get(0));
+    Assert.assertTrue(Integer.parseInt(rows.get(0)) == 0);
+
+    ddf3 = ddf.sql2ddf("select millisecond('2015-01-22 20:23 +0000') from @this");
+    rows = ddf3.VIEWS.head(1);
+    System.out.println(rows.get(0));
+    Assert.assertTrue(Integer.parseInt(rows.get(0)) == 0);
   }
 
 }

--- a/spark/src/test/java/io/ddf/spark/etl/UDFTest.java
+++ b/spark/src/test/java/io/ddf/spark/etl/UDFTest.java
@@ -190,6 +190,11 @@ public class UDFTest extends BaseTest {
     System.out.println(rows.get(0));
     Assert.assertTrue(Integer.parseInt(rows.get(0)) == 4);
 
+    ddf3 = ddf.sql2ddf("select day('2015-01-22 20:23 +0000') from @this");
+    rows = ddf3.VIEWS.head(1);
+    System.out.println(rows.get(0));
+    Assert.assertTrue(Integer.parseInt(rows.get(0)) == 22);
+
     ddf3 = ddf.sql2ddf("select dayofweek('2015-01-22 20:23 +0000', 'number') from @this");
     rows = ddf3.VIEWS.head(1);
     System.out.println(rows.get(0));

--- a/spark/src/test/java/io/ddf/spark/etl/UDFTest.java
+++ b/spark/src/test/java/io/ddf/spark/etl/UDFTest.java
@@ -111,6 +111,16 @@ public class UDFTest extends BaseTest {
     System.out.println(rows.get(0));
     Assert.assertTrue(Integer.parseInt(rows.get(0))== 2015);
 
+    ddf3 = ddf.sql2ddf("select extract('2015-01-22 20:23 +0000', 'weekyear') from @this");
+    rows = ddf3.VIEWS.head(1);
+    System.out.println(rows.get(0));
+    Assert.assertTrue(Integer.parseInt(rows.get(0))== 2015);
+
+    ddf3 = ddf.sql2ddf("select extract('2015-01-22 20:23 +0000', 'weekofweekyear') from @this");
+    rows = ddf3.VIEWS.head(1);
+    System.out.println(rows.get(0));
+    Assert.assertTrue(Integer.parseInt(rows.get(0))== 4);
+
     ddf3 = ddf.sql2ddf("select extract('2015-01-22 20:23 +0000', 'month') from @this");
     rows = ddf3.VIEWS.head(1);
     System.out.println(rows.get(0));
@@ -142,5 +152,33 @@ public class UDFTest extends BaseTest {
     Assert.assertTrue(Integer.parseInt(rows.get(0))== 0);
   }
 
+  @Test
+  public void testIndividualDateTimeExtractUDFs() throws DDFException {
+    // Make sure the output of data_parse is consumable to other UDFs
+    DDF ddf3 = ddf.sql2ddf("select year('2015-01-22 20:23 +0000') from @this");
+    List<String> rows = ddf3.VIEWS.head(1);
+    System.out.println(rows.get(0));
+    Assert.assertTrue(Integer.parseInt(rows.get(0)) == 2015);
+
+    ddf3 = ddf.sql2ddf("select dayofweek('2015-01-22 20:23 +0000', 'number') from @this");
+    rows = ddf3.VIEWS.head(1);
+    System.out.println(rows.get(0));
+    Assert.assertTrue(rows.get(0).equalsIgnoreCase("4"));
+
+    ddf3 = ddf.sql2ddf("select dayofweek('2015-01-22 20:23 +0000', 'text') from @this");
+    rows = ddf3.VIEWS.head(1);
+    System.out.println(rows.get(0));
+    Assert.assertTrue(rows.get(0).equalsIgnoreCase("Thursday"));
+
+    ddf3 = ddf.sql2ddf("select dayofweek('2015-01-22 20:23 +0000', 'shorttext') from @this");
+    rows = ddf3.VIEWS.head(1);
+    System.out.println(rows.get(0));
+    Assert.assertTrue(rows.get(0).equalsIgnoreCase("Thu"));
+
+    ddf3 = ddf.sql2ddf("select hour('2015-01-22 20:23 +0000') from @this");
+    rows = ddf3.VIEWS.head(1);
+    System.out.println(rows.get(0));
+    Assert.assertTrue(Integer.parseInt(rows.get(0)) == 20);
+  }
 
 }


### PR DESCRIPTION
Done: year, dayofweek, hour
DayOfWeek UDF can extract day of week in numeric, text and short text
format
To do: to_date, quarter, month, day, weekofyear, minute, second