### PR TITLE
don't serialize abundant credentials

### DIFF
--- a/core/src/main/java/io/ddf/datasource/S3DataSourceCredentials.java
+++ b/core/src/main/java/io/ddf/datasource/S3DataSourceCredentials.java
@@ -4,7 +4,7 @@ package io.ddf.datasource;
  * Created by jing on 7/16/15.
  */
 public class S3DataSourceCredentials implements IDataSourceCredentials {
-    private String credentials;
+    private transient String credentials;
     private String awsKeyID;
     private String awsSecretKey;
 

--- a/core/src/main/java/io/ddf/datasource/S3DataSourceURI.java
+++ b/core/src/main/java/io/ddf/datasource/S3DataSourceURI.java
@@ -7,8 +7,8 @@ import java.net.URISyntaxException;
  * Created by jing on 7/16/15.
  */
 public class S3DataSourceURI extends DataSourceURI {
-    private String awsKeyID = null;
-    private String awsSecretKey = null;
+    private transient String awsKeyID = null;
+    private transient String awsSecretKey = null;
 
     public S3DataSourceURI(String uri) throws URISyntaxException {
         super(new URI(uri));


### PR DESCRIPTION
make credentials field in S3DataSourceCredentials transient
same for awsKeyID and awsSecretKey in S3DataSourceURI