### PR TITLE
fix array in sql parser

### DIFF
--- a/core/src/main/java/io/ddf/TableVisitor.java
+++ b/core/src/main/java/io/ddf/TableVisitor.java
@@ -480,6 +480,17 @@ public class TableVisitor
         // TODO: Not supported.
     }
 
+    @Override
+    public void visit(SQLArray sqlArray) throws Exception {
+        if (sqlArray.getColumn() != null) {
+            visit(sqlArray.getColumn());
+        }
+
+        if (sqlArray.getFunc() != null) {
+            sqlArray.getFunc().accept(this);
+        }
+    }
+
     public void visit(SubJoin subjoin) throws Exception {
         subjoin.getLeft().accept(this);
         subjoin.getJoin().getRightItem().accept(this);
@@ -600,5 +611,6 @@ public class TableVisitor
     public void visit(ClusterByElement clusterByElement) throws Exception {
         clusterByElement.getExpression().accept(this);
     }
+
 
 }

--- a/project/RootBuild.scala
+++ b/project/RootBuild.scala
@@ -114,7 +114,7 @@ object RootBuild extends Build {
     "commons-configuration" % "commons-configuration" % "1.6",
     "com.google.code.gson"% "gson" % "2.2.2",
     "com.novocode" % "junit-interface" % "0.10" % "test",
-    "net.sf" % "jsqlparser" % "0.9.8.3",
+    "net.sf" % "jsqlparser" % "0.9.8.4",
     "org.jblas" % "jblas" % "1.2.3", // for fast linear algebra
     //"org.apache.derby" % "derby" % "10.4.2.0",
    // "org.apache.spark" % "spark-streaming_2.10" % SPARK_VERSION excludeAll(excludeSpark),
@@ -180,7 +180,7 @@ object RootBuild extends Build {
       "com.novocode" % "junit-interface" % "0.10" % "test",	
       "org.jblas" % "jblas" % "1.2.3", // for fast linear algebra
       "com.googlecode.matrix-toolkits-java" % "mtj" % "0.9.14",
-      "net.sf" % "jsqlparser" % "0.9.8.3", 
+      "net.sf" % "jsqlparser" % "0.9.8.4", 
       "commons-io" % "commons-io" % "1.3.2",
       "org.easymock" % "easymock" % "3.1" % "test",
       "mysql" % "mysql-connector-java" % "5.1.25",

--- a/project/RootBuild.scala
+++ b/project/RootBuild.scala
@@ -114,7 +114,7 @@ object RootBuild extends Build {
     "commons-configuration" % "commons-configuration" % "1.6",
     "com.google.code.gson"% "gson" % "2.2.2",
     "com.novocode" % "junit-interface" % "0.10" % "test",
-    "net.sf" % "jsqlparser" % "0.9.8.4",
+    "net.sf" % "jsqlparser" % "0.9.8.5",
     "org.jblas" % "jblas" % "1.2.3", // for fast linear algebra
     //"org.apache.derby" % "derby" % "10.4.2.0",
    // "org.apache.spark" % "spark-streaming_2.10" % SPARK_VERSION excludeAll(excludeSpark),
@@ -180,7 +180,7 @@ object RootBuild extends Build {
       "com.novocode" % "junit-interface" % "0.10" % "test",	
       "org.jblas" % "jblas" % "1.2.3", // for fast linear algebra
       "com.googlecode.matrix-toolkits-java" % "mtj" % "0.9.14",
-      "net.sf" % "jsqlparser" % "0.9.8.4", 
+      "net.sf" % "jsqlparser" % "0.9.8.5", 
       "commons-io" % "commons-io" % "1.3.2",
       "org.easymock" % "easymock" % "3.1" % "test",
       "mysql" % "mysql-connector-java" % "5.1.25",


### PR DESCRIPTION
This PR fix the array syntax in parser:
(1) select split(col, '\t')[0] from tablename
(2) select column[0] from tablename

Jiras:
https://adatao.atlassian.net/browse/PE-1016
https://adatao.atlassian.net/browse/PE-1075

/cc @Huandao0812 @nhanitvn @mbbui 