### PR TITLE
add model support in ddf

### DIFF
--- a/core/src/main/java/io/basic/ddf/content/ModelPersistenceHandler.java
+++ b/core/src/main/java/io/basic/ddf/content/ModelPersistenceHandler.java
@@ -1,0 +1,104 @@
+package io.basic.ddf.content;
+
+import io.ddf.ml.IModel;
+import io.ddf.misc.Config;
+import io.ddf.util.Utils;
+import io.ddf.exception.DDFException;
+import java.io.IOException;
+
+/**
+ * Created by steveyan on 10/28/15.
+ */
+public class ModelPersistenceHandler {
+    private IModel model;
+
+    public ModelPersistenceHandler(IModel model){
+        this.model = model;
+    }
+
+    /**
+     * find the directory in hdfs for model: hdfs:ddf-runtime/basic-model-db
+     * @return
+     * @throws DDFException
+     */
+    public static String locateOrCreateModelPersistenceDirectory() throws DDFException {
+        String result;
+
+        try {
+            result = Utils.locateOrCreateDirectory(Config.getBasicModelPersistenceDir());
+
+        } catch (Exception e) {
+            throw new DDFException(String.format("Unable to getModelPersistenceDirectory"), e);
+        }
+
+        return result;
+    }
+
+    /**
+     * find the full directory in hdfs for model: hdfs:ddf-runtime/basic-model-db/adatao
+     * @param subdir
+     * @return
+     * @throws DDFException
+     */
+    public static String locateOrCreateModelPersistenceSubdirectory(String subdir) throws DDFException {
+        String result = null, path = null;
+
+        try {
+            path = String.format("%s/%s", locateOrCreateModelPersistenceDirectory(), subdir);
+            result = Utils.locateOrCreateDirectory(path);
+
+        } catch (Exception e) {
+            throw new DDFException(String.format("Unable to getModelPersistenceSubdirectory(%s)", path), e);
+        }
+
+        return result;
+    }
+
+    /**
+     * find the full model file in hdfs for model: hdfs:ddf-runtime/basic-model-db/adatao/some_uuid.model
+     * @param modelName
+     * @return
+     * @throws DDFException
+     */
+    public static String getModelFileFullName(String modelName) throws DDFException {
+        String namespace = Config.getGlobalValue("Namespace");
+        String directory = locateOrCreateModelPersistenceSubdirectory(namespace);
+        String postfix = ".model";
+
+        return String.format("%s/%s%s", directory, modelName, postfix);
+    }
+
+    public static String getModelFileFullName(IModel model) throws DDFException {
+        return getModelFileFullName(model.getName());
+    }
+
+    public static void persistModel(IModel model, boolean overwrite) throws DDFException {
+
+        String modelFile = getModelFileFullName(model);
+
+        try {
+            if (!overwrite && (Utils.fileExists(modelFile))) {
+                throw new DDFException("Model file already exists in persistence storage, and overwrite option is false");
+            }
+        } catch (IOException e) {
+            throw new DDFException(e);
+        }
+
+        try {
+            //if overwrite and existed
+            if (overwrite && Utils.fileExists(modelFile)) {
+                Utils.deleteFile(modelFile);
+            }
+
+            Utils.writeObjectToFile(modelFile, model);
+        } catch (Exception e) {
+            if (e instanceof DDFException) throw (DDFException) e;
+            else throw new DDFException(e);
+        }
+    }
+
+    public static IModel getModelFromFile(String modelName) throws DDFException, IOException, ClassNotFoundException {
+        IModel model = (IModel) Utils.readFromObjectFile(getModelFileFullName(modelName));
+        return model;
+    }
+}

--- a/core/src/main/java/io/ddf/misc/Config.java
+++ b/core/src/main/java/io/ddf/misc/Config.java
@@ -32,6 +32,9 @@ public class Config {
     return String.format("%s/%s", getRuntimeDir(), getGlobalValue(ConfigConstant.FIELD_BASIC_PERSISTENCE_DIRECTORY));
   }
 
+  public static String getBasicModelPersistenceDir() throws IOException {
+    return String.format("%s/%s", getRuntimeDir(), getGlobalValue(ConfigConstant.FIELD_BASIC_MODEL_PERSISTENCE_DIRECTORY));
+  }
 
   public static String getValue(ConfigConstant section, ConfigConstant key) {
     return getValue(section.toString(), key.toString());
@@ -114,6 +117,7 @@ public class Config {
             .set("Namespace", "adatao") //
             .set("RuntimeDir", "ddf-runtime") //
             .set("BasicPersistenceDir", "basic-ddf-db") //
+            .set("BasicModelPersistenceDir", "basic-model-db") //
             .set("DDF", "io.ddf.DDF") //
             .set("io.ddf.DDF", "io.ddf.DDFManager") //
             .set("ISupportStatistics", "io.ddf.analytics.AStatisticsSupporter") //
@@ -170,7 +174,7 @@ public class Config {
     SECTION_GLOBAL("global"), 
     
     FIELD_RUNTIME_DIR("RuntimeDir"), FIELD_NAMESPACE("Namespace"), FIELD_DDF("DDF"), FIELD_DDF_MANAGER("DDFManager"),
-    FIELD_BASIC_PERSISTENCE_DIRECTORY("BasicPersistenceDir"),
+    FIELD_BASIC_PERSISTENCE_DIRECTORY("BasicPersistenceDir"),FIELD_BASIC_MODEL_PERSISTENCE_DIRECTORY("BasicModelPersistenceDir"),
 
     JDBC_DRIVER("Driver"), DEFAULT_JDBC_DRIVER("com.mysql.jdbc"),
     SFDC_JDBC_DRIVER("Driver"), DEFAULT_SFDC_JDBC_DRIVER("cdata.jdbc.salesforce.SalesforceDriver"),

--- a/core/src/main/java/io/ddf/util/Utils.java
+++ b/core/src/main/java/io/ddf/util/Utils.java
@@ -247,6 +247,48 @@ public class Utils {
     }
   }
 
+  public static Object readFromObjectFile(String fileName) throws IOException, ClassNotFoundException {
+    ObjectInputStream reader = null;
+    FileSystem hdfs = null;
+    Configuration configuration = getConfiguration();
+
+    try {
+      hdfs = FileSystem.get(configuration);
+      FSDataInputStream inputStream = hdfs.open(new Path(fileName));
+      reader = new ObjectInputStream(new BufferedInputStream(inputStream));
+      Object obj = reader.readObject();
+
+      return obj;
+    } catch (IOException ex) {
+      throw new IOException(String.format("Cannot read from file %s", fileName, ex));
+
+    } finally {
+      reader.close();
+      hdfs.close();
+    }
+  }
+
+  public static void writeObjectToFile(String fileName, Object obj) throws IOException {
+    ObjectOutputStream writer = null;
+    FileSystem hdfs = null;
+    Configuration configuration =  getConfiguration();
+
+    try {
+      hdfs = FileSystem.get(configuration);
+      FSDataOutputStream outputStream = hdfs.create(new Path(fileName));
+
+      writer = new ObjectOutputStream(new BufferedOutputStream(outputStream));
+      writer.writeObject(obj);
+
+    } catch (IOException ex) {
+      throw new IOException(String.format("Cannot write to file %s", fileName, ex));
+
+    } finally {
+      writer.close();
+      hdfs.close();
+    }
+  }
+
   /**
    * @param str e.g., "a, b, c"
    *            Add a comment to this line

--- a/ddf-conf/ddf.ini
+++ b/ddf-conf/ddf.ini
@@ -5,6 +5,7 @@ Namespace = adatao
 RuntimeDir = ddf-runtime
 ; The basic-persistence database directory, just below runtime/
 BasicPersistenceDir = basic-ddf-db
+BasicModelPersistenceDir = basic-model-db
 DDF = io.ddf.DDF
 DDFManager = io.ddf.DDFManager
 ISupportStatistics = io.ddf.analytics.AStatisticsSupporter

--- a/project/RootBuild.scala
+++ b/project/RootBuild.scala
@@ -265,6 +265,7 @@ object RootBuild extends Build {
               <artifactId>maven-surefire-plugin</artifactId>
               <version>2.15</version>
               <configuration>
+		<argLine>-Xmx2g -XX:MaxPermSize=512m</argLine>
                 <reuseForks>false</reuseForks>
                 <enableAssertions>false</enableAssertions>
                 <environmentVariables>


### PR DESCRIPTION
@Huandao0812 @nhanitvn please review the code:
This is the temp model persistence code. When Add Model, it will add the model to HashMap cache (existing), as well as to hdfs with override if exists in hdfs already, the location is similar to the DDF persistence in hdfs, with post fix ".model". When read a model, it checks the HashMap cache first, if not in cache, it read from hdfs, and add to cache.

@mbbui the code is in the DDF repo, which will be open sourced, should it be in pAnalytics/DDF?

Thanks!

Steve