### PR TITLE
modify err msg when ddfs are not enough in the list

### DIFF
--- a/core/src/main/java/io/ddf/TableNameReplacer.java
+++ b/core/src/main/java/io/ddf/TableNameReplacer.java
@@ -370,7 +370,8 @@ public class TableNameReplacer extends TableVisitor {
                     "if you use {number} as index, the number should begin from 1");
         }
         if (idx > identifierList.size()) {
-            throw new Exception(new ArrayIndexOutOfBoundsException());
+            throw new DDFException(String.format("Don't have enough ddfs in the list. The index is %d and the ddf " +
+                "number is %d", idx, identifierList.size()));
         } else {
             String identifier = identifierList.get(idx - 1);
 


### PR DESCRIPTION
This PR is to fix the unclear error message when we don't pass in enough ddfs in sql.

session.sql("select * from {1}, {2} where {1}.id={2}.id", ddfs=["ddf://adatao/test"])
PyClientServerException: ERR_SPARK_QUERY_FAILED: Unable to execute the query. (Diagnostic message: Don't have enough ddfs in the list. The index is 2 and the ddf number is 1) (Command: Sql2ListString, Command ID: b3460ae3-b8cc-11e5-beb7-a45e60ccc2fd, Response code: 12)

/cc @hai-adatao @nhanitvn @Huandao0812