### PR TITLE
Add method to validate data source credential

### DIFF
--- a/core/src/main/java/io/basic/ddf/BasicDDFManager.java
+++ b/core/src/main/java/io/basic/ddf/BasicDDFManager.java
@@ -7,6 +7,7 @@ package io.basic.ddf;
 import io.ddf.DDF;
 import io.ddf.DDFManager;
 import io.ddf.content.Schema;
+import io.ddf.ds.DataSourceCredential;
 import io.ddf.exception.DDFException;
 
 import java.util.List;
@@ -66,6 +67,11 @@ public class BasicDDFManager extends DDFManager {
   @Override
   public DDF createDDF(Map<Object, Object> options) throws DDFException {
     throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void validateCredential(DataSourceCredential credential) throws DDFException {
+    // do nothing
   }
 
   @Override

--- a/core/src/main/java/io/ddf/DDFManager.java
+++ b/core/src/main/java/io/ddf/DDFManager.java
@@ -28,6 +28,7 @@ import io.ddf.datasource.DataFormat;
 import io.ddf.datasource.DataSourceDescriptor;
 import io.ddf.datasource.DataSourceManager;
 import io.ddf.datasource.SQLDataSourceDescriptor;
+import io.ddf.ds.DataSourceCredential;
 import io.ddf.etl.IHandleSqlLike;
 import io.ddf.exception.DDFException;
 import io.ddf.misc.ALoggable;
@@ -653,6 +654,8 @@ public abstract class DDFManager extends ALoggable implements IDDFManager, IHand
   }
 
   public abstract DDF createDDF(Map<Object, Object> options) throws DDFException;
+
+  public abstract void validateCredential(DataSourceCredential credential) throws DDFException;
 
   public abstract String getSourceUri();
 }

--- a/core/src/main/java/io/ddf/exception/InvalidDataSourceCredentialException.java
+++ b/core/src/main/java/io/ddf/exception/InvalidDataSourceCredentialException.java
@@ -1,0 +1,20 @@
+package io.ddf.exception;
+
+public class InvalidDataSourceCredentialException extends DDFException {
+
+  public InvalidDataSourceCredentialException() {
+    this("Invalid Data Source Credential");
+  }
+
+  public InvalidDataSourceCredentialException(String msg) {
+    super(msg);
+  }
+
+  public InvalidDataSourceCredentialException(String msg, Throwable cause) {
+    super(msg, cause);
+  }
+
+  public InvalidDataSourceCredentialException(Throwable cause) {
+    super(cause);
+  }
+}

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -316,6 +316,12 @@
     </dependencies>
     <repositories>
         <repository>
+            <id>typesafereleases</id>
+            <name>typesafe-releases</name>
+            <url>http://repo.typesafe.com/typesafe/releases/</url>
+            <layout>default</layout>
+        </repository>
+        <repository>
             <id>AdataoMvnreposSnapshots</id>
             <name>Adatao Mvnrepos Snapshots</name>
             <url>https://raw.github.com/adatao/mvnrepos/master/snapshots/</url>

--- a/spark/src/main/java/io/ddf/spark/SparkDDFManager.java
+++ b/spark/src/main/java/io/ddf/spark/SparkDDFManager.java
@@ -8,11 +8,9 @@ import io.ddf.DDFManager;
 import io.ddf.content.Schema;
 import io.ddf.datasource.DataSourceDescriptor;
 import io.ddf.datasource.JDBCDataSourceDescriptor;
+import io.ddf.ds.DataSourceCredential;
 import io.ddf.exception.DDFException;
 import io.ddf.spark.ds.DataSource;
-import io.ddf.spark.ds.FileDataSource;
-import io.ddf.spark.ds.JdbcDataSource;
-import io.ddf.spark.ds.S3DataSource;
 import io.ddf.spark.etl.DateParseUDF;
 import io.ddf.spark.etl.DateTimeExtractUDF;
 import io.ddf.spark.etl.DateUDF;
@@ -371,21 +369,20 @@ public class SparkDDFManager extends DDFManager {
 
   @Override
   public DDF createDDF(Map<Object, Object> options) throws DDFException {
-    Preconditions.checkArgument(options.containsKey("sourceUri"),
-        "SparkDDFManager need sourceUri param in options");
+    Preconditions.checkArgument(options.containsKey("dataSource"),
+        "SparkDDFManager need dataSource param in options");
 
-    String uri = options.get("sourceUri").toString();
-    DataSource ds;
-    if (uri.startsWith("s3:")) {
-      ds = new S3DataSource(uri, this);
-    } else if (uri.startsWith("hdfs:") || uri.startsWith("file:")) {
-      ds = new FileDataSource(uri, this);
-    } else if (uri.startsWith("jdbc:")) {
-      ds = new JdbcDataSource(uri, this);
-    } else {
-      throw new DDFException("Unsupported datasource " + uri);
-    }
+    Object dsObject = options.get("dataSource");
+    Preconditions.checkArgument(dsObject instanceof DataSource,
+        "dataSource option is not of DataSource type");
+
+    DataSource ds = (DataSource) dsObject;
     return ds.loadDDF(options);
+  }
+
+  @Override
+  public void validateCredential(DataSourceCredential credential) throws DDFException {
+    // no credential needed for spark, do nothing here
   }
 
   @Override

--- a/spark/src/main/scala/io/ddf/spark/ds/DataSource.scala
+++ b/spark/src/main/scala/io/ddf/spark/ds/DataSource.scala
@@ -1,6 +1,8 @@
 package io.ddf.spark.ds
 
-import io.ddf.{DDFManager, DDF}
+import io.ddf.ds.DataSourceCredential
+import io.ddf.{DDF, DDFManager}
+
 import scala.collection.JavaConversions.mapAsScalaMap
 
 trait DataSource {
@@ -9,6 +11,8 @@ trait DataSource {
   def loadDDF(options: java.util.Map[AnyRef, AnyRef]): DDF = {
     loadDDF(options.toMap)
   }
+
+  def validateCredential(credential: DataSourceCredential): Unit
 }
 
 abstract class BaseDataSource(val uri: String, val ddfManager: DDFManager) extends DataSource

--- a/spark/src/main/scala/io/ddf/spark/ds/FileDataSource.scala
+++ b/spark/src/main/scala/io/ddf/spark/ds/FileDataSource.scala
@@ -1,7 +1,7 @@
 package io.ddf.spark.ds
 
 import io.ddf.content.Schema
-import io.ddf.ds.UsernamePasswordCredential
+import io.ddf.ds.{DataSourceCredential, UsernamePasswordCredential}
 import io.ddf.exception.{DDFException, UnauthenticatedDataSourceException}
 import io.ddf.spark.SparkDDFManager
 import io.ddf.spark.util.SparkUtils
@@ -18,7 +18,6 @@ import scala.util.{Success, Try}
   * @param uri URI of the data source,
   *            should be "file:;" for local file system and "hdfs://namenode" for HDFS.
   *            "hdfs:;" can be used for the local HDFS file system if running on YARN.
-  *
   * @param manager the DDF manager for this source
   */
 class FileDataSource(uri: String, manager: DDFManager) extends BaseDataSource(uri, manager) {
@@ -100,6 +99,10 @@ class FileDataSource(uri: String, manager: DDFManager) extends BaseDataSource(ur
       s"$uri$path"
     }
   }
+
+  override def validateCredential(credential: DataSourceCredential): Unit = {
+    // do nothing
+  }
 }
 
 /**
@@ -132,6 +135,9 @@ class S3DataSource(uri: String, manager: DDFManager) extends FileDataSource(uri,
     }
   }
 
+  override def validateCredential(credential: DataSourceCredential): Unit = {
+    // XXX TODO implement S3 credential check here
+  }
 }
 
 object S3DataSource {

--- a/spark/src/test/scala/io/ddf/spark/ds/CreateDDFSuite.scala
+++ b/spark/src/test/scala/io/ddf/spark/ds/CreateDDFSuite.scala
@@ -1,7 +1,7 @@
 package io.ddf.spark.ds
 
 import io.ddf.ds.UsernamePasswordCredential
-import io.ddf.exception.UnauthenticatedDataSourceException
+import io.ddf.exception.{InvalidDataSourceCredentialException, UnauthenticatedDataSourceException}
 import io.ddf.spark.{ATestSuite, DelegatingDDFManager}
 import org.scalatest.Matchers
 
@@ -64,6 +64,13 @@ class CreateDDFSuite extends ATestSuite with Matchers {
     )
     a[UnauthenticatedDataSourceException] should be thrownBy {
       s3Manager.createDDF(options)
+    }
+  }
+
+  test("invalid credential used") {
+    val invalidCredential = new UsernamePasswordCredential("foo", "bar")
+    a[InvalidDataSourceCredentialException] should be thrownBy {
+      mysqlManager.validateCredential(invalidCredential)
     }
   }
 


### PR DESCRIPTION
This PR add a new method validateCredential to DDFManager and implement for SparkDDFManager with JDBC data source.

/cc @Huandao0812 @PangZhi @hai-adatao 