### PR TITLE
[DDF] file system support: s3/hdfs, file format support: avro/orc

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -351,12 +351,6 @@
     </dependencies>
     <repositories>
         <repository>
-            <id>typesafereleases</id>
-            <name>typesafe-releases</name>
-            <url>http://repo.typesafe.com/typesafe/releases/</url>
-            <layout>default</layout>
-        </repository>
-        <repository>
             <id>AdataoMvnreposSnapshots</id>
             <name>Adatao Mvnrepos Snapshots</name>
             <url>https://raw.github.com/adatao/mvnrepos/master/snapshots/</url>

--- a/core/src/main/java/io/basic/ddf/BasicDDFManager.java
+++ b/core/src/main/java/io/basic/ddf/BasicDDFManager.java
@@ -46,8 +46,8 @@ public class BasicDDFManager extends DDFManager {
       throw new DDFException("Non-null/zero-length List is required to instantiate a new BasicDDF");
     }
 
-    return this.newDDF(this, rows, new Class[] { List.class, unitType },
-         namespace, name, schema);
+    return this.newDDF(this, rows, new Class[]{List.class, unitType},
+        namespace, name, schema);
   }
 
   public DDF loadTable(String fileURL, String fieldSeparator) throws DDFException {
@@ -65,8 +65,8 @@ public class BasicDDFManager extends DDFManager {
   }
 
   @Override
-  public DDF createDDF(Map<Object, Object> options) throws DDFException {
-    throw new UnsupportedOperationException();
+  public DDF copyFrom(DDF fromDDF) throws DDFException {
+    throw new DDFException(new UnsupportedOperationException());
   }
 
   @Override
@@ -77,5 +77,10 @@ public class BasicDDFManager extends DDFManager {
   @Override
   public String getSourceUri() {
     return "basic://";
+  }
+
+  @Override
+  public DDF createDDF(Map<Object, Object> options) throws DDFException {
+    throw new UnsupportedOperationException();
   }
 }

--- a/core/src/main/java/io/ddf/DDFManager.java
+++ b/core/src/main/java/io/ddf/DDFManager.java
@@ -86,26 +86,16 @@ public abstract class DDFManager extends ALoggable implements IDDFManager, IHand
     POSTGRES,
     AWS,
     REDSHIFT,
-    BASIC
+    BASIC,
+    S3,
+    HDFS
     ;
 
     public static EngineType fromString(String str) throws DDFException {
-      if (str.equalsIgnoreCase("spark")) {
-        return SPARK;
-      } else if (str.equalsIgnoreCase("jdbc")) {
-        return JDBC;
-      } else if (str.equalsIgnoreCase("sfdc")) {
-        return SFDC;
-      } else if (str.equalsIgnoreCase("postgres")) {
-        return POSTGRES;
-      } else if(str.equalsIgnoreCase("aws")) {
-        return AWS;
-      } else if(str.equalsIgnoreCase("redshift")) {
-        return REDSHIFT;
-      } else if(str.equalsIgnoreCase("basic")) {
-        return BASIC;
-      } else {
-        throw new DDFException("Engine type should be either spark, jdbc, postgres, aws, redshift, basic");
+      try {
+        return EngineType.valueOf(str.toUpperCase());
+      } catch (RuntimeException e) {
+        throw new DDFException("Unknown engine type: " + str, e);
       }
     }
   }
@@ -269,8 +259,8 @@ public abstract class DDFManager extends ALoggable implements IDDFManager, IHand
 
     try {
       Class[] classType = new Class[2];
-      classType[0] = DataSourceDescriptor.class;
-      classType[1] = EngineType.class;
+      classType[0] = dataSourceDescriptor.getClass();
+      classType[1] = engineType.getClass();
 
       DDFManager manager = (DDFManager) Class.forName(className).getDeclaredConstructor(classType)
           .newInstance(dataSourceDescriptor, engineType);
@@ -652,6 +642,14 @@ public abstract class DDFManager extends ALoggable implements IDDFManager, IHand
   public DDF load(DataSourceDescriptor ds) throws DDFException {
     return (new DataSourceManager()).load(ds, this);
   }
+
+  /**
+   * @brief Copy the ddf content and return a local ddf.
+   * @param fromDDF The ddf from other engine. From example, copy a s3DDF/JDBCDDF into spark.
+   * @return
+   * @throws DDFException
+   */
+  public abstract DDF copyFrom(DDF fromDDF) throws DDFException;
 
   public abstract DDF createDDF(Map<Object, Object> options) throws DDFException;
 

--- a/core/src/main/java/io/ddf/datasource/DataFormat.java
+++ b/core/src/main/java/io/ddf/datasource/DataFormat.java
@@ -1,7 +1,7 @@
 package io.ddf.datasource;
 
 public enum DataFormat {
-  UNDEF, SQL, CSV, TSV, JSON, PQT;
+  UNDEF, SQL, CSV, TSV, JSON, PQT, AVRO, ORC;
 
   public static DataFormat fromInt(int x) {
     switch(x) {
@@ -15,24 +15,12 @@ public enum DataFormat {
         return JSON;
       case 4:
         return PQT;
+      case 5:
+        return AVRO;
+      case 6:
+        return ORC;
       default:
         return UNDEF;
-    }
-  }
-
-  public static DataFormat fromString(String x) {
-    if (x.equalsIgnoreCase("SQL")) {
-      return SQL;
-    } else if (x.equalsIgnoreCase("CSV")) {
-      return CSV;
-    } else if (x.equalsIgnoreCase("TSV")) {
-      return TSV;
-    } else if (x.equalsIgnoreCase("JSON")) {
-      return JSON;
-    } else if (x.equalsIgnoreCase("PQT") || x.equalsIgnoreCase("parquet")) {
-      return PQT;
-    } else {
-      return UNDEF;
     }
   }
 }

--- a/core/src/main/java/io/ddf/datasource/DataSourceResolver.java
+++ b/core/src/main/java/io/ddf/datasource/DataSourceResolver.java
@@ -18,8 +18,8 @@ public class DataSourceResolver {
 
   public static DataSourceDescriptor resolve(String source,
                         Map<String, String> options) throws DDFException, URISyntaxException {
-    switch (source) {
-      case "S3": {
+    switch (source.toLowerCase()) {
+      case "s3": {
         return resolveS3(options);
       }
       case "hdfs": {
@@ -48,12 +48,13 @@ public class DataSourceResolver {
       LOG.info("Loading from S3 with options: {}", sourceOptions);
     }
 
-    String uri = options.get("uri");
-    String awsKeyID = getOrDefault(options,"awsKeyID", "");
+    String uri = getOrDefault(options, "uri", "");
+    String awsKeyID = getOrDefault(options, "awsKeyID", "");
     String awsSecretKey = getOrDefault(options,"awsSecretKey", "");
-    String schema = options.get("schema");
-    // TODO format null?
-    DataFormat format = DataFormat.fromInt(Integer.parseInt(options.get("dataFormat")));
+    String schema = getOrDefault(options, "schema", null);
+    DataFormat format = options.containsKey("dataFormat")?
+        DataFormat.fromInt(Integer.parseInt(options.get("dataFormat"))) :
+        DataFormat.CSV;
     if (options.get("serde") != null) {
       String serde = options.get("serde");
       return new S3DataSourceDescriptor(uri, awsKeyID, awsSecretKey, schema, serde, format);
@@ -69,9 +70,11 @@ public class DataSourceResolver {
 
   public static HDFSDataSourceDescriptor resolveHDFS(Map<String, String> options) throws DDFException, URISyntaxException {
     String uri = options.get("uri");
-    String schema = getOrDefault(options,"schema", null);
+    String schema = getOrDefault(options, "schema", null);
     String originalSource = getOrDefault(options,"originalSource", "hdfs");
-    DataFormat format = DataFormat.fromInt(Integer.parseInt(options.get("dataFormat")));
+    DataFormat format = options.containsKey("dataFormat")?
+        DataFormat.fromInt(Integer.parseInt(options.get("dataFormat"))) :
+        DataFormat.CSV;
     LOG.info("Loading from HDFS with options: {}", options);
     if(options.containsKey("serde")) {
       String serde = options.get("serde");

--- a/ddf-conf/ddf.ini
+++ b/ddf-conf/ddf.ini
@@ -71,3 +71,10 @@ IHandleRepresentations = io.ddf.content.RepresentationHandler
 IHandleSchema = io.ddf.content.SchemaHandler
 IHandleMetaData = com.adatao.ddf.spark.content.MetaDataHandler
 
+[s3]
+DDFManager = io.ddf.s3.S3DDFManager
+DDF = io.ddf.s3.S3DDF
+
+[hdfs]
+DDFManager = io.ddf.hdfs.HDFSDDFManager
+DDF = io.ddf.hdfs.HDFSDDF

--- a/ddf-test/pom.xml
+++ b/ddf-test/pom.xml
@@ -315,12 +315,6 @@
     </dependencies>
     <repositories>
         <repository>
-            <id>typesafereleases</id>
-            <name>typesafe-releases</name>
-            <url>http://repo.typesafe.com/typesafe/releases/</url>
-            <layout>default</layout>
-        </repository>
-        <repository>
             <id>AdataoMvnreposSnapshots</id>
             <name>Adatao Mvnrepos Snapshots</name>
             <url>https://raw.github.com/adatao/mvnrepos/master/snapshots/</url>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -316,12 +316,6 @@
     </dependencies>
     <repositories>
         <repository>
-            <id>typesafereleases</id>
-            <name>typesafe-releases</name>
-            <url>http://repo.typesafe.com/typesafe/releases/</url>
-            <layout>default</layout>
-        </repository>
-        <repository>
             <id>AdataoMvnreposSnapshots</id>
             <name>Adatao Mvnrepos Snapshots</name>
             <url>https://raw.github.com/adatao/mvnrepos/master/snapshots/</url>

--- a/hdfs/src/main/java/io/ddf/hdfs/HDFSDDF.java
+++ b/hdfs/src/main/java/io/ddf/hdfs/HDFSDDF.java
@@ -1,0 +1,119 @@
+package io.ddf.hdfs;
+
+import com.google.common.base.Strings;
+import io.ddf.DDF;
+import io.ddf.datasource.DataFormat;
+import io.ddf.exception.DDFException;
+
+import java.util.Map;
+
+/**
+ * Created by jing on 2/22/16.
+ */
+public class HDFSDDF extends DDF {
+    // It's a directory or file.
+    private Boolean mIsDir;
+
+    // The format of this s3ddf. If it's a folder, we requires that all the files in the folder should have the same
+    // format, otherwise the dataformat will be set to the dataformat of the first file under this folder.
+    private DataFormat mDataFormat;
+
+    // Schema String.
+    private String mSchemaString;
+
+    // File path.
+    private String mPath;
+
+    private Map<String, String> options;
+
+    /**
+     * S3DDF is the ddf for s3. It point to a single S3DDFManager, and every S3DDF is a unqiue mapping to a s3 uri.
+     * The schema should store the s3 uri as tablename.
+     */
+    public HDFSDDF(HDFSDDFManager manager, String path, String schema, Map<String, String> options) throws DDFException {
+        super(manager, null, null, null, null, null);
+        mSchemaString = schema;
+        mPath = path;
+        this.options = options;
+        initialize();
+    }
+
+    public HDFSDDF(HDFSDDFManager manager, String path, Map<String, String> options) throws DDFException {
+        super(manager, null, null, null, null, null);
+        mPath = path;
+        this.options = options;
+        initialize();
+    }
+
+
+    private void initialize() throws DDFException {
+        // Check key and path
+        if (Strings.isNullOrEmpty(mPath)) {
+            throw new DDFException("The path of hdfsddf is null");
+        }
+        // Check directory or file.
+        HDFSDDFManager hdfsDDFManager = this.getManager();
+        // Check dataformat.
+        if (options != null && options.containsKey("format")) {
+            try {
+                mDataFormat = DataFormat.valueOf(options.get("format"));
+            } catch (IllegalArgumentException e) {
+                mIsDir = hdfsDDFManager.isDir(this);
+                mDataFormat = hdfsDDFManager.getDataFormat(this);
+            }
+        } else {
+            mIsDir = hdfsDDFManager.isDir(this);
+            mDataFormat = hdfsDDFManager.getDataFormat(this);
+        }
+    }
+
+    public DataFormat getDataFormat() {
+        return mDataFormat;
+    }
+
+    public void setDataFormat(DataFormat dataFormat) {
+        this.mDataFormat = dataFormat;
+    }
+
+    public Boolean getIsDir() {
+        return mIsDir;
+    }
+
+    public void setIsDir(Boolean isDir) {
+        this.mIsDir = isDir;
+    }
+
+    public String getPath() {
+        return mPath;
+    }
+
+    public void setPath(String path) {
+        this.mPath = path;
+    }
+
+    public String getSchemaString() {
+        return mSchemaString;
+    }
+
+    public void setSchemaString(String schemaString) {
+        this.mSchemaString = schemaString;
+    }
+
+    public Map<String, String> getOptions() {
+        return options;
+    }
+
+    public void setOptions(Map<String, String> options) {
+        this.options = options;
+    }
+
+    @Override
+    public HDFSDDFManager getManager() {
+        return (HDFSDDFManager)super.getManager();
+    }
+
+    @Override
+    public DDF copy() throws DDFException {
+        throw new DDFException(new UnsupportedOperationException());
+    }
+}

--- a/hdfs/src/main/java/io/ddf/hdfs/HDFSDDFManager.java
+++ b/hdfs/src/main/java/io/ddf/hdfs/HDFSDDFManager.java
@@ -1,0 +1,252 @@
+package io.ddf.hdfs;
+
+import io.ddf.DDF;
+import io.ddf.DDFManager;
+import io.ddf.datasource.DataFormat;
+import io.ddf.datasource.HDFSDataSourceDescriptor;
+import io.ddf.ds.DataSourceCredential;
+import io.ddf.exception.DDFException;
+
+import com.google.common.base.Strings;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.*;
+
+/**
+ * Created by jing on 2/22/16.
+ */
+//TODO: Extract FileDDFManager as an abstract class for s3 and hdfs.
+public class HDFSDDFManager extends DDFManager {
+  // File system connector.
+  private FileSystem fs = null;
+  // Upper limit for content preview.
+  private static final int K_LIMIT = 1000;
+  private String fsUri = null;
+
+  public HDFSDDFManager(HDFSDataSourceDescriptor hdfsDataSourceDescriptor, EngineType engineType) throws DDFException {
+    this(hdfsDataSourceDescriptor.getDataSourceUri().getUri().toString());
+  }
+
+  public HDFSDDFManager(String fsUri) throws DDFException {
+    assert !Strings.isNullOrEmpty(fsUri);
+    this.fsUri = fsUri;
+    try {
+      Configuration conf = new Configuration();
+      conf.set("fs.defaultFS", fsUri);
+      this.fs = FileSystem.get(conf);
+    } catch (IOException e) {
+      throw new DDFException(e);
+    }
+  }
+
+  /**
+   * @brief To check whether the ddf is a directory.
+   */
+  public Boolean isDir(HDFSDDF hdfsDDF) throws DDFException {
+    String path = hdfsDDF.getPath();
+    try {
+      FileStatus fileStatus = fs.getFileStatus(new Path(path));
+      return fileStatus.isDirectory();
+    } catch (IOException e) {
+      throw new DDFException(e);
+    }
+  }
+
+  /**
+   * @breif To get the dataformat.
+   */
+  public DataFormat getDataFormat(HDFSDDF hdfsDDF) throws DDFException {
+    if (hdfsDDF.getIsDir()) {
+      try {
+        FileStatus[] files = this.fs.listStatus(new Path(hdfsDDF.getPath()));
+        if (files.length == 0) {
+          throw new DDFException(String.format("There is no file under %s", hdfsDDF.getPath()));
+        }
+        HashSet<DataFormat> dataFormats = new HashSet<>();
+        for (FileStatus file : files) {
+          String filePath = file.getPath().toString();
+          int dotIndex = filePath.lastIndexOf('.');
+          int slashIndex = filePath.lastIndexOf('/');
+          // Check for extension.
+          if (dotIndex != -1 && dotIndex > slashIndex) {
+            String extension = filePath.substring(dotIndex + 1);
+            try {
+              if (extension.equalsIgnoreCase("parquet")) {
+                extension = "pqt";
+              }
+              DataFormat dataFormat = DataFormat.valueOf(extension.toUpperCase());
+              dataFormats.add(dataFormat);
+            } catch (Exception e) {
+              throw new DDFException(String.format("Unsupported dataformat: %s", extension));
+            }
+          }
+        }
+        if (dataFormats.size() > 1) {
+          throw new DDFException(String.format("Find more than 1 formats of data under the directory %s: %s", hdfsDDF
+              .getPath(), dataFormats.toArray().toString()));
+        } else if (dataFormats.size() == 1) {
+          return dataFormats.iterator().next();
+        } else {
+          return DataFormat.CSV;
+        }
+      } catch (IOException e) {
+        throw new DDFException(String.format("Can't open directory : %s", hdfsDDF.getPath()));
+      }
+    } else {
+      String filePath = hdfsDDF.getPath();
+      int dotIndex = filePath.lastIndexOf('.');
+      if (dotIndex != -1) {
+        return DataFormat.valueOf(filePath.substring(dotIndex + 1).toUpperCase());
+      } else {
+        // CSV by default
+        return DataFormat.CSV;
+      }
+    }
+  }
+
+  /**
+   * @param path The path.
+   * @return The list of file names
+   * @brief List all the files (including directories under one path)
+   */
+  public List<String> listFiles(String path) throws DDFException {
+    List<String> ret = new ArrayList<>();
+    try {
+      FileStatus[] status = fs.listStatus(new Path(path));
+      for (int i = 0; i < status.length; i++) {
+        ret.add(status[i].getPath().toString());
+      }
+    } catch (IOException e) {
+      throw new DDFException(e);
+    }
+    return ret;
+  }
+
+
+  /**
+   * @param path The path.
+   * @brief Create a ddf given path.
+   */
+
+  public HDFSDDF newDDF(String path) throws DDFException {
+    return this.newDDF(path, null);
+  }
+
+  public HDFSDDF newDDF(String path, Map<String, String> options) throws DDFException {
+    return this.newDDF(path, null, options);
+  }
+
+  public HDFSDDF newDDF(String path, String schema, Map<String, String> options) throws DDFException {
+    return new HDFSDDF(this, path, schema, options);
+  }
+
+
+  /**
+   * @brief Show the first several rows of the s3ddf.
+   */
+  public List<String> head(HDFSDDF hdfsDDF, int limit) throws DDFException {
+    if (limit > K_LIMIT) {
+      limit = K_LIMIT;
+    }
+
+    List<String> rows = new ArrayList<String>();
+
+    int pos = 0;
+    String s = null;
+
+    if (!hdfsDDF.getIsDir()) {
+      try (BufferedReader br = new BufferedReader(new InputStreamReader(fs.open(new Path(hdfsDDF.getPath()))))) {
+        while ((s = br.readLine()) != null && pos < limit) {
+          rows.add(s);
+          ++pos;
+        }
+      } catch (IOException e) {
+        e.printStackTrace();
+      }
+    } else {
+      RemoteIterator<LocatedFileStatus> files = null;
+      try {
+        files = fs.listFiles(new Path(hdfsDDF.getPath()), false);
+        while (files.hasNext() && pos < limit) {
+          LocatedFileStatus lfs = files.next();
+          try (BufferedReader br = new BufferedReader(
+              new InputStreamReader(
+                  fs.open(lfs.getPath())))) {
+            while ((s = br.readLine()) != null && pos < limit) {
+              rows.add(s);
+              ++pos;
+            }
+          } catch (IOException e) {
+            e.printStackTrace();
+          }
+        }
+      } catch (IOException e) {
+        throw new DDFException(e);
+      }
+    }
+    return rows;
+  }
+
+  @Override
+  public DDF transfer(UUID fromEngine, UUID ddfuuid) throws DDFException {
+    throw new DDFException(new UnsupportedOperationException());
+  }
+
+  @Override
+  public DDF transferByTable(UUID fromEngine, String tableName) throws DDFException {
+    throw new DDFException(new UnsupportedOperationException());
+  }
+
+  @Override
+  public DDF loadTable(String fileURL, String fieldSeparator) throws DDFException {
+    throw new DDFException(new UnsupportedOperationException());
+  }
+
+  @Override
+  public DDF getOrRestoreDDFUri(String ddfURI) throws DDFException {
+    return null;
+  }
+
+  @Override
+  public DDF getOrRestoreDDF(UUID uuid) throws DDFException {
+    return null;
+  }
+
+  @Override
+  public DDF copyFrom(DDF fromDDF) throws DDFException {
+    throw new DDFException(new UnsupportedOperationException());
+  }
+
+  @Override
+  public DDF createDDF(Map<Object, Object> options) throws DDFException {
+    return null;
+  }
+
+  @Override
+  public void validateCredential(DataSourceCredential credential) throws DDFException {
+
+  }
+
+  @Override
+  public String getSourceUri() {
+    return this.fsUri;
+  }
+
+  @Override
+  public String getEngine() {
+    return "hdfs";
+  }
+
+  public void stop() {
+    // close connection
+  }
+}

--- a/hdfs/src/test/java/io/ddf/hdfs/HDFSDDFManagerTests.java
+++ b/hdfs/src/test/java/io/ddf/hdfs/HDFSDDFManagerTests.java
@@ -1,0 +1,105 @@
+package io.ddf.hdfs;
+
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+import io.ddf.datasource.DataFormat;
+import io.ddf.exception.DDFException;
+
+
+public class HDFSDDFManagerTests {
+
+    public static HDFSDDFManager manager;
+    public static Logger LOG;
+
+    @Test
+    public void testDDFConfig() throws Exception {
+        Assert.assertEquals("hdfs", manager.getEngine());
+    }
+
+    @BeforeClass
+    public static void startServer() throws Exception {
+        LOG = LoggerFactory.getLogger(HDFSDDFManagerTests.class);
+        manager = new HDFSDDFManager(System.getenv("HDFS_URI"));
+    }
+
+    @Test
+    public void testListing() throws DDFException {
+        List<String> files = manager.listFiles("/test_pe");
+        assert (files.size() > 0);
+
+    }
+
+    @Test
+    public void testCreateDDF() throws DDFException {
+        try {
+            HDFSDDF folderDDF = manager.newDDF("/test_pe/", null, null);
+            assert false;
+        } catch (Exception e) {
+
+        }
+
+        HDFSDDF cleanFolderDDF = manager.newDDF("/test_pe/csv/multiple", null, null);
+        HDFSDDF jsonDDF = manager.newDDF("/test_pe/json/noheader", null, null);
+        HDFSDDF csvDDF = manager.newDDF("/test_pe/csv/noheader", null, null);
+        assert (cleanFolderDDF.getIsDir() == true);
+        assert(jsonDDF.getIsDir() == false);
+        assert(csvDDF.getIsDir() == false);
+        assert(jsonDDF.getDataFormat().equals(DataFormat.JSON));
+        assert(csvDDF.getDataFormat().equals(DataFormat.CSV));
+        try {
+            // Test on non-exist folder/file. Should throw exception.
+            HDFSDDF nonExistDDF = manager.newDDF("/test_pe/nonexist.csv", null, null);
+            assert (false);
+        } catch (Exception e) {
+
+        }
+        try {
+            HDFSDDF nonExistDDF2 = manager.newDDF("/test_pe/nonexist", null, null);
+            assert (false);
+        } catch (Exception e) {
+
+        }
+
+        HDFSDDF pqtDDF = manager.newDDF("/test_pe/parquet/default", null, null);
+        assert (pqtDDF.getIsDir() == true);
+        assert (pqtDDF.getDataFormat().equals(DataFormat.PQT));
+
+
+        HDFSDDF avroDDF = manager.newDDF("/test_pe/avro/single", null, null);
+        assert (avroDDF.getIsDir() == true);
+        assert (avroDDF.getDataFormat().equals(DataFormat.AVRO));
+
+        HDFSDDF orcDDF = manager.newDDF("/test_pe/orc/default", null, null);
+        assert (orcDDF.getIsDir() == true);
+        assert (orcDDF.getDataFormat().equals(DataFormat.ORC));
+    }
+
+
+    @Test
+    public void testHead() throws DDFException {
+        HDFSDDF csvDDF = manager.newDDF("/test_pe/csv/small/1.csv", null, null);
+        List<String> rows = manager.head(csvDDF, 5);
+        assert(rows.size() == 2);
+
+        rows = manager.head(csvDDF, 20000);
+        assert(rows.size() == 2);
+
+        rows = manager.head(csvDDF, 1000);
+        assert(rows.size() == 2);
+
+        HDFSDDF folderDDF = manager.newDDF("/test_pe/csv/small", null, null);
+        rows = manager.head(folderDDF, 5);
+        assert (rows.size() == 4);
+
+        HDFSDDF ddf1024 = manager.newDDF("/test_pe/csv/fixed_len/1024.csv", null, null);
+        rows = manager.head(ddf1024, 9999);
+        assert (rows.size() == 1000);
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,9 @@
 	<modules>
 	  	<module>core</module>
 	  	<module>spark</module>
-	  	<module>examples</module>
+	  	<module>s3</module>
+		<module>hdfs</module>
+		<module>examples</module>
 		<module>ddf-test</module>
 	</modules>
 

--- a/project/RootBuild.scala
+++ b/project/RootBuild.scala
@@ -15,7 +15,7 @@ object RootBuild extends Build {
   val OBSELETE_HADOOP_VERSION = "1.0.4"
   val DEFAULT_HADOOP_VERSION = "2.2.0"
 
-  val SPARK_VERSION = "1.5.1-adatao"
+  val SPARK_VERSION = "1.6.0-adatao-1.7.0"
 
   val YARN_ENABLED = env("SPARK_YARN").getOrElse("true").toBoolean
 
@@ -46,6 +46,12 @@ object RootBuild extends Build {
   val sparkProjectName = "ddf_spark"
   val sparkVersion = rootVersion
 
+  val s3ProjectName = "ddf_s3"
+  val s3Version = rootVersion
+
+  val hdfsProjectName = "ddf_hdfs"
+  val hdfsVersion = rootVersion
+  
   val testProjectName = "ddf_test"
   val testVersion = rootVersion
 
@@ -65,12 +71,13 @@ object RootBuild extends Build {
 
 
   // lazy val root = Project("root", file("."), settings = rootSettings) aggregate(core, spark, examples)
-  lazy val root = Project("root", file("."), settings = rootSettings) aggregate(core, spark, examples, test_ddf)
+  lazy val root = Project("root", file("."), settings = rootSettings) aggregate(core, spark, s3, hdfs, examples, test_ddf)
   lazy val core = Project("core", file("core"), settings = coreSettings)
   lazy val test_ddf = Project("ddf-test", file("ddf-test"), settings = testSettings) dependsOn (core)
-  lazy val spark = Project("spark", file("spark"), settings = sparkSettings) dependsOn (test_ddf % "test") dependsOn (core)
+  lazy val spark = Project("spark", file("spark"), settings = sparkSettings) dependsOn (test_ddf % "test") dependsOn (core, s3, hdfs)
   lazy val examples = Project("examples", file("examples"), settings = examplesSettings) dependsOn (spark) dependsOn (core)
-
+  lazy val s3 = Project("s3", file("s3"), settings = s3Settings) dependsOn (core)
+  lazy val hdfs = Project("hdfs", file("hdfs"), settings = hdfsSettings) dependsOn(core)
   // A configuration to set an alternative publishLocalConfiguration
   lazy val MavenCompile = config("m2r") extend(Compile)
   lazy val publishLocalBoth = TaskKey[Unit]("publish-local", "publish local for m2 and ivy")
@@ -111,6 +118,8 @@ object RootBuild extends Build {
   val scalaDependencies = scalaArtifacts.map( artifactId => "org.scala-lang" % artifactId % theScalaVersion)
 
   val spark_dependencies = Seq(
+    "com.databricks" % "spark-csv_2.10" % "1.4.0",
+    "com.databricks" % "spark-avro_2.10" % "2.0.1",
     "commons-configuration" % "commons-configuration" % "1.6",
     "com.google.code.gson"% "gson" % "2.2.2",
     "com.novocode" % "junit-interface" % "0.10" % "test",
@@ -127,8 +136,15 @@ object RootBuild extends Build {
     "org.apache.spark" % "spark-hive_2.10" % SPARK_VERSION exclude("io.netty", "netty-all") exclude ("com.google.code.findbugs", "jsr305")
       exclude("org.jboss.netty", "netty") exclude("org.mortbay.jetty", "jetty") exclude("org.mortbay.jetty", "servlet-api"),
     //"org.apache.spark" % "spark-yarn_2.10" % SPARK_VERSION exclude("io.netty", "netty-all")
-    "com.google.protobuf" % "protobuf-java" % "2.5.0",
-    "com.databricks" % "spark-csv_2.10" % "1.3.0"
+    "com.google.protobuf" % "protobuf-java" % "2.5.0"
+  )
+  
+  val s3_dependencies = Seq(
+    "com.amazonaws" % "aws-java-sdk" % "1.10.8"
+  )
+
+  val hdfs_dependencies = Seq(
+    "org.apache.hadoop" % "hadoop-hdfs" % "2.2.0"
   )
 
   val test_dependencies = Seq(
@@ -202,7 +218,7 @@ object RootBuild extends Build {
     publishMavenStyle in MavenCompile := true,
     publishLocal in MavenCompile <<= publishTask(publishLocalConfiguration in MavenCompile, deliverLocal),
     publishLocalBoth <<= Seq(publishLocal in MavenCompile, publishLocal).dependOn,
-
+    publishArtifact in (Compile, packageDoc) := false,
 
     dependencyOverrides += "commons-lang" % "commons-lang" % "2.6",
     dependencyOverrides += "it.unimi.dsi" % "fastutil" % "6.4.4",
@@ -210,7 +226,7 @@ object RootBuild extends Build {
     dependencyOverrides += "org.slf4j" % "slf4j-api" % slf4jVersion,
     dependencyOverrides += "org.slf4j" % "slf4j-log4j12" % slf4jVersion,
     dependencyOverrides += "commons-io" % "commons-io" % "2.4", //tachyon 0.2.1
-    dependencyOverrides += "org.apache.httpcomponents" % "httpclient" % "4.1.3", //libthrift
+    dependencyOverrides += "org.apache.httpcomponents" % "httpclient" % "4.4.1", //libthrift
     dependencyOverrides += "com.google.guava" % "guava" % "14.0.1", //spark-core
     dependencyOverrides += "org.codehaus.jackson" % "jackson-core-asl" % "1.8.8",
     dependencyOverrides += "org.codehaus.jackson" % "jackson-mapper-asl" % "1.8.8",
@@ -220,7 +236,7 @@ object RootBuild extends Build {
     dependencyOverrides += "com.fasterxml.jackson.core" % "jackson-annotations" % "2.4.4",
     dependencyOverrides += "com.thoughtworks.paranamer" % "paranamer" % "2.4.1", //net.liftweb conflict with avro
     dependencyOverrides += "org.xerial.snappy" % "snappy-java" % "1.0.5", //spark-core conflicts with avro
-    dependencyOverrides += "org.apache.httpcomponents" % "httpcore" % "4.1.4",
+    dependencyOverrides += "org.apache.httpcomponents" % "httpcore" % "4.4.1",
     dependencyOverrides += "org.apache.avro" % "avro-ipc" % "1.7.4",
     dependencyOverrides += "org.apache.avro" % "avro" % "1.7.4",
     dependencyOverrides += "org.apache.zookeeper" % "zookeeper" % "3.4.5",
@@ -276,10 +292,10 @@ object RootBuild extends Build {
               <version>2.15</version>
               <configuration>
                 <reuseForks>false</reuseForks>
-                <enableAssertions>false</enableAssertions>
-                <environmentVariables>
-                    <RSERVER_JAR>${{basedir}}/{targetDir}/*.jar,${{basedir}}/{targetDir}/lib/*</RSERVER_JAR>              
-                </environmentVariables>
+	<enableAssertions>false</enableAssertions>
+        <environmentVariables>
+		 <RSERVER_JAR>${{basedir}}/{targetDir}/*.jar,${{basedir}}/{targetDir}/lib/*</RSERVER_JAR>
+	</environmentVariables> 
                 <systemPropertyVariables>
                   <spark.serializer>org.apache.spark.serializer.KryoSerializer</spark.serializer>
                   <spark.kryo.registrator>io.ddf.spark.content.KryoRegistrator</spark.kryo.registrator>
@@ -518,6 +534,20 @@ object RootBuild extends Build {
     compile in Compile <<= compile in Compile andFinally { List("sh", "-c", "touch examples/" + targetDir + "/*timestamp") }
   ) ++ assemblySettings ++ extraAssemblySettings
 
+  def s3Settings = commonSettings ++ Seq(
+    name := s3ProjectName,
+    compile in Compile <<= compile in Compile andFinally { List("sh", "-c", "touch s3/" + targetDir + "/*timestamp") },
+    testOptions in Test += Tests.Argument("-oI"),
+    libraryDependencies ++= s3_dependencies
+  ) ++ assemblySettings ++ extraAssemblySettings
+
+  def hdfsSettings = commonSettings ++ Seq(
+    name := hdfsProjectName,  
+    compile in Compile <<= compile in Compile andFinally { List("sh", "-c", "touch hdfs/" + targetDir + "/*timestamp") },
+    testOptions in Test += Tests.Argument("-oI"),
+    libraryDependencies ++= hdfs_dependencies
+  ) ++ assemblySettings ++ extraAssemblySettings
+  
   def testSettings = commonSettings ++ Seq(
     name := testProjectName,
     libraryDependencies ++= test_dependencies,

--- a/s3/src/main/java/io/ddf/s3/S3DDF.java
+++ b/s3/src/main/java/io/ddf/s3/S3DDF.java
@@ -1,0 +1,173 @@
+package io.ddf.s3;
+
+import com.amazonaws.services.s3.model.S3DataSource;
+import com.google.common.base.Strings;
+import io.ddf.DDF;
+import io.ddf.datasource.DataFormat;
+import io.ddf.datasource.S3DataSourceDescriptor;
+import io.ddf.exception.DDFException;
+
+import org.apache.hadoop.fs.s3.S3Credentials;
+
+import java.util.Map;
+
+/**
+ * Created by jing on 12/2/15.
+ */
+public class S3DDF extends DDF {
+    // It's a directory or file.
+    private Boolean mIsDir;
+
+    // The format of this s3ddf. If it's a folder, we requires that all the files in the folder should have the same
+    // format, otherwise the dataformat will be set to the dataformat of the first file under this folder.
+    private DataFormat mDataFormat;
+
+    // Schema String.
+    private String mSchemaString;
+
+    // Bucket.
+    private String mBucket;
+
+    // Path after bucket.
+    private String mKey;
+
+    // Options, including:
+    // key : possible values
+    // header : true / false
+    // format: csv / parquet / etc.
+    // delimiter : , \x001
+    // quote : "
+    // escape : \
+    // mode : used for spark
+    // charSet:
+    // inferSchema:
+    // comment:
+    // nullvalue:
+    // dateformat:
+    // flatten : true / false
+    private Map<String, String > options;
+
+    /**
+     * S3DDF is the ddf for s3. It point to a single S3DDFManager, and every S3DDF is a unqiue mapping to a s3 uri.
+     */
+    public S3DDF(S3DDFManager manager, String path, Map<String, String> options) throws DDFException {
+        super(manager, null, null, null, null, null);
+        this.getBucketAndPath(path);
+        this.options = options;
+        initialize();
+    }
+
+    public S3DDF(S3DDFManager manager, String path, String schema, Map<String, String> options) throws DDFException {
+        super(manager, null, null, null, null, null);
+        mSchemaString = schema;
+        this.getBucketAndPath(path);
+        this.options = options;
+        initialize();
+    }
+
+
+    public S3DDF(S3DDFManager manager, String bucket, String key, String schema, Map<String, String> options)
+        throws DDFException {
+        super(manager, null, null, null, null, null);
+        mBucket = bucket;
+        mKey = key;
+        mSchemaString = schema;
+        this.options = options;
+        initialize();
+    }
+    
+    /**
+     * @brief Get the bucket and path out of a given uri.
+     * @param path
+     * @return
+     */
+    private void getBucketAndPath(String path) {
+        int firstSlash = path.indexOf('/');
+        mBucket = path.substring(0, firstSlash);
+        mKey = path.substring(firstSlash + 1);
+    }
+
+    private void initialize() throws DDFException {
+        // Check key and path
+        if (Strings.isNullOrEmpty(mBucket)) {
+            throw new DDFException("The bucket of s3ddf is null");
+        }
+        if (Strings.isNullOrEmpty(mKey)) {
+            throw new DDFException("The key of s3ddf is null");
+        }
+
+        mLog.info(String.format("init s3 ddf: %s %s", mBucket, mKey));
+        // Check directory or file.
+        S3DDFManager s3DDFManager = this.getManager();
+        // Check dataformat.
+        if (options != null && options.containsKey("format")) {
+            try {
+                mDataFormat = DataFormat.valueOf(options.get("format"));
+            } catch (IllegalArgumentException e) {
+                mIsDir = s3DDFManager.isDir(this);
+                mDataFormat = s3DDFManager.getDataFormat(this);
+            }
+        } else {
+            mIsDir = s3DDFManager.isDir(this);
+            mDataFormat = s3DDFManager.getDataFormat(this);
+        }
+    }
+
+    public DataFormat getDataFormat() {
+        return mDataFormat;
+    }
+
+    public void setDataFormat(DataFormat dataFormat) {
+        this.mDataFormat = dataFormat;
+    }
+
+    public Boolean getIsDir() {
+        return mIsDir;
+    }
+
+    public void setIsDir(Boolean isDir) {
+        this.mIsDir = isDir;
+    }
+
+    public String getBucket() {
+        return mBucket;
+    }
+
+    public void setBucket(String bucket) {
+        this.mBucket = bucket;
+    }
+
+    public String getKey() {
+        return mKey;
+    }
+
+    public void setKey(String key) {
+        this.mKey = key;
+    }
+
+    public String getSchemaString() {
+        return mSchemaString;
+    }
+
+    public void setSchemaString(String schemaString) {
+        this.mSchemaString = schemaString;
+    }
+
+    public Map<String, String> getOptions() {
+        return options;
+    }
+
+    public void setOptions(Map<String, String> options) {
+        this.options = options;
+    }
+
+    @Override
+    public S3DDFManager getManager() {
+        return (S3DDFManager)super.getManager();
+    }
+
+    @Override
+    public DDF copy() throws DDFException {
+        throw new DDFException(new UnsupportedOperationException());
+    }
+}

--- a/s3/src/main/java/io/ddf/s3/S3DDFManager.java
+++ b/s3/src/main/java/io/ddf/s3/S3DDFManager.java
@@ -1,0 +1,290 @@
+package io.ddf.s3;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.*;
+
+import io.ddf.DDF;
+import io.ddf.DDFManager;
+import io.ddf.datasource.DataFormat;
+import io.ddf.datasource.S3DataSourceCredentials;
+import io.ddf.datasource.S3DataSourceDescriptor;
+import io.ddf.ds.DataSourceCredential;
+import io.ddf.exception.DDFException;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Created by jing on 12/2/15.
+ */
+public class S3DDFManager extends DDFManager {
+  // Descriptor.
+  private S3DataSourceCredentials mCredential;
+
+  // Amazon client connection.
+  private AmazonS3 mConn;
+
+  // Upper limit for content preview.
+  private static final int K_LIMIT = 1000;
+
+  // TODO: Remove Engine Type
+  public S3DDFManager(S3DataSourceDescriptor s3dsd, EngineType engineType) throws DDFException {
+    this((S3DataSourceCredentials) s3dsd.getDataSourceCredentials(), engineType);
+  }
+
+  public S3DDFManager(S3DataSourceCredentials s3Credentials, EngineType engineType) throws DDFException {
+    mCredential = s3Credentials;
+    AWSCredentials credentials = new BasicAWSCredentials(mCredential.getAwsKeyID(), mCredential.getAwsScretKey());
+    mConn = new AmazonS3Client(credentials);
+  }
+
+  public S3DDFManager(S3DataSourceDescriptor s3dsd) throws DDFException {
+    this((S3DataSourceCredentials) s3dsd.getDataSourceCredentials());
+  }
+
+  public S3DDFManager(S3DataSourceCredentials s3Credentials) throws DDFException {
+    this(s3Credentials, EngineType.S3);
+  }
+
+  /**
+   * @brief To check whether the ddf is a directory.
+   */
+  public Boolean isDir(S3DDF s3DDF) throws DDFException {
+    List<String> keys = this.listFiles(s3DDF.getBucket(),s3DDF.getKey());
+    for (String key : keys) {
+      if (key.endsWith("/") && !key.equals(s3DDF.getKey())) {
+        throw new DDFException("This folder contains subfolder, S3 DDF does not support nested folders");
+      }
+    }
+    Boolean isDir = s3DDF.getKey().endsWith("/");
+    return isDir;
+  }
+
+  /**
+   * @breif To get the dataformat.
+   */
+  public DataFormat getDataFormat(S3DDF s3DDF) throws DDFException {
+    if (s3DDF.getIsDir()) {
+      List<String> keys = this.fileKeys(s3DDF);
+      if (keys.isEmpty()) {
+        throw new DDFException("There is no file under " + s3DDF.getBucket() + "/" + s3DDF.getKey());
+      } else {
+        HashSet<DataFormat> dataFormats = new HashSet<>();
+        for (String key : keys) {
+          int dotIndex = key.lastIndexOf('.');
+          int slashIndex = key.lastIndexOf('/');
+          // Check for extension.
+          if (dotIndex != -1 && dotIndex > slashIndex) {
+            String extension = key.substring(dotIndex + 1);
+            try {
+              if (extension.equalsIgnoreCase("parquet")) {
+                extension = "pqt";
+              }
+              DataFormat dataFormat = DataFormat.valueOf(extension.toUpperCase());
+              dataFormats.add(dataFormat);
+            } catch (Exception e) {
+              throw new DDFException(String.format("Unsupported dataformat: %s", extension));
+            }
+          }
+        }
+        if (dataFormats.size() > 1) {
+          throw new DDFException(String.format("Find more than 1 formats of data under the directory %s: " +
+              "%s", s3DDF.getKey(), dataFormats.toArray().toString()));
+        } else if (dataFormats.size() == 1){
+          return dataFormats.iterator().next();
+        } else {
+          return DataFormat.CSV;
+        }
+      }
+    } else {
+      String key = s3DDF.getKey();
+      int dotIndex = key.lastIndexOf('.');
+      if (dotIndex != -1) {
+        return DataFormat.valueOf(key.substring(dotIndex + 1).toUpperCase());
+      } else {
+        // CSV by default
+        return DataFormat.CSV;
+      }
+    }
+  }
+
+  /**
+   * @brief List buckets.
+   */
+  public List<String> listBuckets() {
+    List<Bucket> bucketList = mConn.listBuckets();
+    List<String> ret = new ArrayList<String>();
+    for (Bucket bucket : bucketList) {
+      ret.add(bucket.getName());
+    }
+    return ret;
+  }
+
+  /**
+   * @param bucket The bucket.
+   * @param key    The key.
+   * @return The list of file names (TODO: should we return more info here.)
+   * @brief List all the files (including directories under one path)
+   */
+  public List<String> listFiles(String bucket, String key) {
+    List<String> files = new ArrayList<String>();
+    ObjectListing objects = mConn.listObjects(bucket, key);
+    for (S3ObjectSummary objectSummary : objects.getObjectSummaries()) {
+      files.add(objectSummary.getKey());
+    }
+    return files;
+  }
+
+
+  /**
+   * @param path The path.
+   * @brief Create a ddf given path.
+   */
+  // TODO: switch to builder pattern
+  public S3DDF newDDF(String path) throws DDFException {
+    return this.newDDF(path, null);
+  }
+
+  public S3DDF newDDF(String path, Map<String, String> options) throws DDFException {
+    return this.newDDF(path, null, options);
+  }
+
+  public S3DDF newDDF(String path, String schema, Map<String, String> options) throws DDFException {
+    return new S3DDF(this, path, schema, options);
+  }
+
+  public S3DDF newDDF(String bucket, String key, String schema, Map<String, String> options) throws DDFException {
+    return new S3DDF(this, bucket, key, schema, options);
+  }
+
+  /**
+   * @param s3DDF The s3ddf.
+   * @brief Return the key of the first non-folder file under this folder.
+   */
+  private String firstFileKey(S3DDF s3DDF) throws DDFException {
+    if (s3DDF.getIsDir()) {
+      List<String> ret = this.fileKeys(s3DDF);
+      if (ret.isEmpty()) {
+        throw new DDFException("There is no file under " + s3DDF.getBucket() + "/" + s3DDF.getKey());
+      } else {
+        return ret.get(0);
+      }
+    } else {
+      return s3DDF.getKey();
+    }
+  }
+
+  private List<String> fileKeys(S3DDF s3DDF) throws DDFException {
+    List<String> ret = new ArrayList<String>();
+    ObjectListing objectListing = mConn.listObjects(new ListObjectsRequest().withBucketName(s3DDF.getBucket())
+        .withPrefix(s3DDF.getKey()));
+    for (S3ObjectSummary summary : objectListing.getObjectSummaries()) {
+      if (!summary.getKey().endsWith("/")) {
+        ret.add(summary.getKey());
+      }
+    }
+    return ret;
+  }
+
+  /**
+   * @brief Show the first several rows of the s3ddf.
+   */
+  public List<String> head(S3DDF s3DDF, int limit) throws DDFException {
+    if (limit > K_LIMIT) {
+      limit = K_LIMIT;
+    }
+
+    String bucket = s3DDF.getBucket();
+    List<String> keys = this.fileKeys(s3DDF);
+    List<String> rows = new ArrayList<String>();
+
+    for (int i = 0; i < keys.size() && limit > 0; ++i) {
+      S3Object obj = mConn.getObject(bucket, keys.get(i));
+      try (BufferedReader br = new BufferedReader(
+          new InputStreamReader(obj.getObjectContent()))) {
+        String line = null;
+        while (limit > 0 && ((line = br.readLine()) != null)) {
+          rows.add(line);
+          --limit;
+        }
+      } catch (IOException e) {
+        throw new DDFException(e);
+      }
+
+      try {
+        obj.close();
+      } catch (IOException e) {
+        throw new DDFException(e);
+      }
+    }
+    return rows;
+  }
+
+  @Override
+  public DDF transfer(UUID fromEngine, UUID ddfuuid) throws DDFException {
+    throw new DDFException(new UnsupportedOperationException());
+  }
+
+  @Override
+  public DDF transferByTable(UUID fromEngine, String tableName) throws DDFException {
+    throw new DDFException(new UnsupportedOperationException());
+  }
+
+  @Override
+  public DDF loadTable(String fileURL, String fieldSeparator) throws DDFException {
+    throw new DDFException(new UnsupportedOperationException());
+  }
+
+  @Override
+  public DDF getOrRestoreDDFUri(String ddfURI) throws DDFException {
+    return null;
+  }
+
+  @Override
+  public DDF getOrRestoreDDF(UUID uuid) throws DDFException {
+    return null;
+  }
+
+  @Override
+  public DDF createDDF(Map<Object, Object> options) throws DDFException {
+    return null;
+  }
+
+  @Override
+  public void validateCredential(DataSourceCredential credential) throws DDFException {
+
+  }
+
+  @Override
+  public String getSourceUri() {
+    return null;
+  }
+
+  @Override
+  public DDF copyFrom(DDF fromDDF) throws DDFException {
+    throw new DDFException(new UnsupportedOperationException());
+  }
+
+  @Override
+  public String getEngine() {
+    return "s3";
+  }
+
+  public S3DataSourceCredentials getCredential() {
+    return mCredential;
+  }
+
+  public void stop() {
+    // TODO: Does s3 connection has to be closed?
+  }
+}

--- a/s3/src/test/java/io/ddf/s3/S3DDFManagerTests.java
+++ b/s3/src/test/java/io/ddf/s3/S3DDFManagerTests.java
@@ -1,0 +1,120 @@
+package io.ddf.s3;
+
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Map;
+
+import io.ddf.DDFManager;
+import io.ddf.datasource.DataFormat;
+import io.ddf.datasource.S3DataSourceCredentials;
+import io.ddf.datasource.S3DataSourceDescriptor;
+import io.ddf.datasource.S3DataSourceURI;
+import io.ddf.exception.DDFException;
+
+
+public class S3DDFManagerTests {
+
+    public static S3DDFManager manager;
+    public static Logger LOG;
+
+    @Test
+    public void testDDFConfig() throws Exception {
+        Assert.assertEquals("s3", manager.getEngine());
+    }
+
+    @BeforeClass
+    public static void startServer() throws Exception {
+        LOG = LoggerFactory.getLogger(S3DDFManagerTests.class);
+        S3DataSourceDescriptor  s3dsd = new S3DataSourceDescriptor(new S3DataSourceURI(""),
+            new S3DataSourceCredentials(System.getenv("AWS_ACCESS_KEY_ID"), System.getenv("AWS_SECRET_ACCESS_KEY")),
+            null,
+            null);
+        manager = (S3DDFManager)DDFManager.get(DDFManager.EngineType.S3, s3dsd);
+    }
+
+    @Test
+    public void testListing() throws DDFException {
+        List<String> buckets = manager.listBuckets();
+        LOG.info("========== buckets ==========");
+        assert(buckets.contains("jing-bucket"));
+
+        LOG.info("========== jing-bucket/testFolder/ ==========");
+        List<String> keys = manager.listFiles("jing-bucket", "testFolder/");
+        assert (keys.size()== 21);
+        assert (keys.contains("testFolder/(-_*')!.@&:,$=+?;#.csv"));
+
+        LOG.info("========== jing-bucket/testFolder/a.json ==========");
+        keys = manager.listFiles("jing-bucket", "testFolder/a.json");
+        assert (keys.size()==1);
+
+        keys = manager.listFiles("jing-bucket", "testFolder/(-_*')!.@&:,$=+?;#.csv");
+        assert (keys.size() == 1);
+    }
+
+    @Test
+    public void testCreateDDF() throws DDFException {
+        try {
+            S3DDF folderDDF = manager.newDDF("jing-bucket", "testFolder/", null, null);
+            assert (false);
+            assert(folderDDF.getIsDir() == true);
+        } catch (Exception e) {
+
+        }
+
+        S3DDF cleanFolderDDF = manager.newDDF("jing-bucket", "testFolder/folder/", null, null);
+        S3DDF jsonDDF = manager.newDDF("jing-bucket", "testFolder/a.json", null, null);
+        S3DDF csvDDF = manager.newDDF("jing-bucket", "testFolder/year.csv", null, null);
+        assert (cleanFolderDDF.getIsDir() == true);
+        assert(jsonDDF.getIsDir() == false);
+        assert(csvDDF.getIsDir() == false);
+        assert(jsonDDF.getDataFormat().equals(DataFormat.JSON));
+        assert(csvDDF.getDataFormat().equals(DataFormat.CSV));
+
+        // PQT, AVRO and ORC
+        S3DDF pqtDDF = manager.newDDF("adatao-sample-data", "test/parquet/sleep_parquet/", null, null);
+        assert (pqtDDF.getIsDir() == true);
+        assert (pqtDDF.getDataFormat().equals(DataFormat.PQT));
+
+
+
+        S3DDF avroDDF = manager.newDDF("adatao-sample-data", "test/avro/single/episodes.avro", null, null);
+        assert (avroDDF.getIsDir() == false);
+        assert (avroDDF.getDataFormat().equals(DataFormat.AVRO));
+
+        S3DDF orcDDF = manager.newDDF("adatao-test", "orc/", null, null);
+        assert (orcDDF.getIsDir() == true);
+        assert (orcDDF.getDataFormat().equals(DataFormat.ORC));
+    }
+
+
+    @Test
+    public void testHead() throws DDFException {
+        S3DDF csvDDF = manager.newDDF("jing-bucket", "testFolder/year.csv", null, null);
+        List<String> rows = manager.head(csvDDF, 5);
+        assert(rows.size() == 2);
+        LOG.info("========== content of year.csv ==========");
+        for (String s : rows) {
+            LOG.info(s);
+        }
+
+        rows = manager.head(csvDDF, 20000);
+        assert(rows.size() == 2);
+
+        rows = manager.head(csvDDF, 1000);
+        assert(rows.size() == 2);
+
+        S3DDF folderDDF = manager.newDDF("jing-bucket", "testFolder/folder/", null, null);
+        rows = manager.head(folderDDF, 5);
+        assert (rows.size() == 4);
+
+        S3DDF ddf1024 = manager.newDDF("jing-bucket", "testFolder/1024.csv", null, null);
+        rows = manager.head(ddf1024, 9999);
+        assert (rows.size() == 1000);
+
+    }
+}

--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -226,6 +226,16 @@
             <version>1.4.14-SNAPSHOT</version>
         </dependency>
         <dependency>
+            <groupId>io.ddf</groupId>
+            <artifactId>ddf_s3_2.10</artifactId>
+            <version>1.4.13-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>io.ddf</groupId>
+            <artifactId>ddf_hdfs_2.10</artifactId>
+            <version>1.4.13-SNAPSHOT</version>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>1.7.2</version>
@@ -325,9 +335,19 @@
             <version>1.8.2.compiled</version>
         </dependency>
         <dependency>
+            <groupId>com.databricks</groupId>
+            <artifactId>spark-csv_2.10</artifactId>
+            <version>1.4.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.databricks</groupId>
+            <artifactId>spark-avro_2.10</artifactId>
+            <version>2.0.1</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-core_2.10</artifactId>
-            <version>1.5.1-adatao</version>
+            <version>1.6.0-adatao-1.7.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>net.java.dev.jets3t</groupId>
@@ -354,7 +374,7 @@
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-mllib_2.10</artifactId>
-            <version>1.5.1-adatao</version>
+            <version>1.6.0-adatao-1.7.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.spark</groupId>
@@ -369,7 +389,7 @@
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-sql_2.10</artifactId>
-            <version>1.5.1-adatao</version>
+            <version>1.6.0-adatao-1.7.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>io.netty</groupId>
@@ -388,7 +408,7 @@
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-hive_2.10</artifactId>
-            <version>1.5.1-adatao</version>
+            <version>1.6.0-adatao-1.7.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>io.netty</groupId>
@@ -417,19 +437,8 @@
             <artifactId>protobuf-java</artifactId>
             <version>2.5.0</version>
         </dependency>
-        <dependency>
-            <groupId>com.databricks</groupId>
-            <artifactId>spark-csv_2.10</artifactId>
-            <version>1.3.0</version>
-        </dependency>
     </dependencies>
     <repositories>
-        <repository>
-            <id>typesafereleases</id>
-            <name>typesafe-releases</name>
-            <url>http://repo.typesafe.com/typesafe/releases/</url>
-            <layout>default</layout>
-        </repository>
         <repository>
             <id>AdataoMvnreposSnapshots</id>
             <name>Adatao Mvnrepos Snapshots</name>

--- a/spark/src/main/java/io/ddf/spark/DelegatingDDFManager.java
+++ b/spark/src/main/java/io/ddf/spark/DelegatingDDFManager.java
@@ -64,6 +64,11 @@ public class DelegatingDDFManager extends DDFManager {
   }
 
   @Override
+  public DDF copyFrom(DDF fromDDF) throws DDFException {
+    return null;
+  }
+
+  @Override
   public DDF createDDF(Map<Object, Object> options) throws DDFException {
     // clone the options so that we can add our new field for source uri
     options = new HashMap<>(options);

--- a/spark/src/main/java/io/ddf/spark/SparkDDFManager.java
+++ b/spark/src/main/java/io/ddf/spark/SparkDDFManager.java
@@ -2,14 +2,21 @@ package io.ddf.spark;
 
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.gson.Gson;
 import io.ddf.DDF;
 import io.ddf.DDFManager;
 import io.ddf.content.Schema;
+import io.ddf.datasource.DataFormat;
 import io.ddf.datasource.DataSourceDescriptor;
 import io.ddf.datasource.JDBCDataSourceDescriptor;
+import io.ddf.datasource.S3DataSourceCredentials;
+import io.ddf.datasource.S3DataSourceDescriptor;
 import io.ddf.ds.DataSourceCredential;
 import io.ddf.exception.DDFException;
+import io.ddf.hdfs.HDFSDDF;
+import io.ddf.spark.content.SchemaHandler;
 import io.ddf.spark.ds.DataSource;
 import io.ddf.spark.etl.DateParseUDF;
 import io.ddf.spark.etl.DateTimeExtractUDF;
@@ -20,6 +27,10 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.spark.SparkContext;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.rdd.RDD;
+import org.apache.spark.sql.DataFrame;
+import org.apache.spark.sql.DataFrameReader;
+import org.apache.spark.sql.Row;
 import org.apache.spark.sql.hive.HiveContext;
 
 import java.io.File;
@@ -27,8 +38,9 @@ import java.net.URISyntaxException;
 import java.security.SecureRandom;
 import java.util.*;
 
-//import shark.SharkEnv;
-//import shark.api.JavaSharkContext;
+import org.apache.spark.sql.types.StructType;
+
+import io.ddf.s3.S3DDF;
 
 /**
  * An Apache-Spark-based implementation of DDFManager
@@ -54,7 +66,7 @@ public class SparkDDFManager extends DDFManager {
           DDFException {
 
     mLog.info("Get the engine " + fromEngine + " to transfer table : " +
-            tableName);
+        tableName);
     DDFManager fromManager = this.getDDFCoordinator().getEngine(fromEngine);
     DataSourceDescriptor dataSourceDescriptor = fromManager
             .getDataSourceDescriptor();
@@ -74,6 +86,11 @@ public class SparkDDFManager extends DDFManager {
         } catch (URISyntaxException e) {
           throw new DDFException(e);
         }
+      } else if (dataSourceDescriptor instanceof S3DataSourceDescriptor) {
+        // Load from s3.
+        // Load data into spark. If has schema and doesn't has schema?
+        // Create ddf over it. Take care about persistence & lineage.
+        throw new DDFException("Unsupported operation");
       } else {
         JDBCDataSourceDescriptor loadDS
                 = new JDBCDataSourceDescriptor(jdbcDS.getDataSourceUri(),
@@ -85,34 +102,6 @@ public class SparkDDFManager extends DDFManager {
                 + ", " + loadDS.getDbTable());
         return this.load(loadDS);
       }
-      // TODO
-      /*
-      if (fromManager.getEngine().equals("sfdc")) {
-        options.put("url", jdbcDataSourceDescriptor.getDataSourceUri().getUri
-                ().toString());
-        mLog.info("sfdc uri: " + jdbcDataSourceDescriptor.getDataSourceUri()
-                .getUri().toString());
-      } else {
-        options.put("url", jdbcDataSourceDescriptor.getDataSourceUri().getUri()
-                .toString() + "?user=" + jdbcCredential.getUsername() +
-                "&password="+jdbcCredential.getPassword());
-
-      }
-
-
-      // TODO: Pay attention here. Some maybe username?
-      // options.put("user", jdbcCredential.getUserName());
-      // options.put("password", jdbcCredential.getPassword());
-      // TODO: What if sfdc.
-      DataFrame rdd = mHiveContext.load("jdbc", options);
-      if (rdd == null) {
-        throw new DDFException("fail use spark datasource api");
-      }
-      Schema schema = SchemaHandler.getSchemaFromDataFrame(rdd);
-      DDF ddf = this.newDDF(this, rdd, new Class<?>[]
-              {DataFrame.class}, null, null, null, schema);
-      ddf.getRepresentationHandler().get(new Class<?>[]{RDD.class, Row.class});
-      */
     } else {
       throw new DDFException("Currently no other DataSourceDescriptor is " +
               "supported");
@@ -129,8 +118,96 @@ public class SparkDDFManager extends DDFManager {
       throw new DDFException("There is no ddf with uri : " + ddfUUID.toString()
           + " in another engine");
     }
+
     String fromTableName = fromDDF.getTableName();
     return this.transferByTable(fromEngine, fromTableName);
+  }
+
+
+
+  @Override
+  public DDF copyFrom(DDF ddf) throws DDFException {
+    if (ddf instanceof S3DDF || ddf instanceof HDFSDDF) {
+      DataFormat dataFormat = null;
+      String uri = null;
+      StructType schema = null;
+      Map<String, String> options = null;
+      final Map<DataFormat, String> formatMapping = ImmutableMap.<DataFormat, String>builder()
+          .put(DataFormat.CSV, "com.databricks.spark.csv")
+          .put(DataFormat.JSON, "json")
+          .put(DataFormat.TSV, "com.databricks.spark.csv")
+          .put(DataFormat.PQT, "parquet")
+          .put(DataFormat.ORC, "orc")
+          .put(DataFormat.AVRO, "com.databricks.spark.avro").build();
+
+      final Set<DataFormat> flattenFormat = ImmutableSet.<DataFormat>builder()
+          .add(DataFormat.JSON, DataFormat.ORC, DataFormat.AVRO).build();
+
+      if (ddf instanceof S3DDF) {
+        S3DDF s3DDF = (S3DDF)ddf;
+        S3DataSourceCredentials cred = s3DDF.getManager().getCredential();
+        uri = String.format("s3n://%s:%s@%s/%s", cred.getAwsKeyID(), cred.getAwsScretKey(),
+            s3DDF.getBucket(), s3DDF.getKey());
+        dataFormat = s3DDF.getDataFormat();
+        if (s3DDF.getSchemaString() != null) {
+          schema = SparkUtils.str2SparkSchema(s3DDF.getSchemaString());
+        }
+        options = s3DDF.getOptions();
+      } else {
+        HDFSDDF hdfsDDF = (HDFSDDF) ddf;
+        uri = String.format("%s%s", hdfsDDF.getManager().getSourceUri(), hdfsDDF.getPath());
+        dataFormat = hdfsDDF.getDataFormat();
+        if (hdfsDDF.getSchemaString() != null) {
+          schema = SparkUtils.str2SparkSchema(hdfsDDF.getSchemaString());
+        }
+        options = hdfsDDF.getOptions();
+      }
+
+      DataFrameReader dfr =  this.getHiveContext().read().format(formatMapping.get(dataFormat));
+      DataFrame df = null;
+      switch (dataFormat) {
+        case TSV:
+          if (options == null || !options.containsKey("delimiter")) {
+            dfr = dfr.option("delimiter", "\t");
+          }
+          // fall through
+        case CSV:
+          // TODO: reuse ddf schema.
+          if (schema == null) {
+            dfr = dfr.option("inferSchema", "true");
+          } else {
+            dfr = dfr.schema(schema);
+          }
+          break;
+      }
+      if (options != null) {
+        dfr = dfr.options(options);
+      }
+      mLog.info(String.format(">>>>>>>> Load data from uri: %s", uri));
+      try {
+        df = dfr.load(uri);
+      } catch (Exception e) {
+        throw new DDFException(e);
+      }
+      mLog.info(String.format(">>>>>>>> Finish loading for uri: %s", uri));
+      if (ddf.getSchema() == null) {
+        ddf.getSchemaHandler().setSchema(SchemaHandler.getSchemaFromDataFrame(df));
+      }
+      DDF newDDF = this.newDDF(this, df, new Class<?>[] {DataFrame.class}, null,
+          null, ddf.getSchema());
+      newDDF.getRepresentationHandler().cache(false);
+      newDDF.getRepresentationHandler().get(new Class<?>[]{RDD.class, Row.class});
+
+      if (flattenFormat.contains(dataFormat)
+          && options != null
+          && options.get("flatten") != null
+          && options.get("flatten").equals("true")) {
+        newDDF = newDDF.getFlattenedDDF();
+      }
+      return newDDF;
+    } else {
+      throw new DDFException(new UnsupportedOperationException());
+    }
   }
 
   /**

--- a/spark/src/main/scala/io/ddf/spark/util/SparkUtils.scala
+++ b/spark/src/main/scala/io/ddf/spark/util/SparkUtils.scala
@@ -59,10 +59,23 @@ object SparkUtils {
     val cols: ArrayList[Column] = Lists.newArrayList();
     for(field <- schema.fields) {
       val colType = spark2DDFType(field.dataType)
-      val colName = field.name
+      val colName = field.name.trim
       cols.add(new Column(colName, colType))
     }
     new Schema(null, cols)
+  }
+
+
+  def str2SparkSchema(schema: String): StructType = {
+    StructType(
+      schema.split(",").map(
+        attr => {
+          val nameAndType = attr.trim.split(" ")
+          StructField(nameAndType(0), str2SparkType(nameAndType(1)), true )
+        }
+
+      )
+    )
   }
 
   /**
@@ -122,10 +135,6 @@ object SparkUtils {
     }
 
   }
-//
-//  def jsonForComplexType(df: DataFrame, sep: String): Array[String] = {
-//    df2txt(df, sep)
-//  }
 
   /**
    *
@@ -252,6 +261,8 @@ object SparkUtils {
     df.select(colNames :_*)
   }
 
+
+
   def spark2DDFType(colType: DataType): Schema.ColumnType = {
     //println(colType)
     colType match {
@@ -270,6 +281,21 @@ object SparkUtils {
       case StructType(_) => Schema.ColumnType.STRUCT
       case ArrayType(_, _) => Schema.ColumnType.ARRAY
       case MapType(_, _, _) => Schema.ColumnType.MAP
+      case x => throw new DDFException(s"Type not support $x")
+    }
+  }
+
+  def str2SparkType(str: String): DataType = {
+    // TODO, add more type here
+    str.toLowerCase match {
+      case "string" => StringType
+      case "int" => IntegerType
+      case "long" => LongType
+      case "double" => DoubleType
+      case "float" => FloatType
+      case "timestamp" => TimestampType
+      case "datetype" => DateType
+      case "boolean" => BooleanType
       case x => throw new DDFException(s"Type not support $x")
     }
   }

--- a/spark/src/test/java/io/ddf/spark/SparkDDFManagerTests.java
+++ b/spark/src/test/java/io/ddf/spark/SparkDDFManagerTests.java
@@ -2,12 +2,27 @@ package io.ddf.spark;
 
 
 import io.ddf.DDF;
+import io.ddf.DDFManager;
+import io.ddf.datasource.S3DataSourceCredentials;
+import io.ddf.datasource.S3DataSourceDescriptor;
+import io.ddf.datasource.S3DataSourceURI;
 import io.ddf.exception.DDFException;
+import io.ddf.hdfs.HDFSDDF;
+import io.ddf.hdfs.HDFSDDFManager;
+import io.ddf.s3.S3DDF;
+import io.ddf.s3.S3DDFManager;
+
+
+import com.google.common.collect.ImmutableMap;
 import org.junit.Assert;
 import org.junit.Test;
+import org.slf4j.LoggerFactory;
 
+import java.net.URISyntaxException;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public class SparkDDFManagerTests extends BaseTest {
 
@@ -20,8 +35,8 @@ public class SparkDDFManagerTests extends BaseTest {
   @Test
   public void testLongSparkDDFManagerRetrieval() throws DDFException {
     Map<String, String> params = ((SparkDDFManager) manager).getSparkContextParams();
-    System.out.println(System.getProperty("spark.serializer"));
-    System.out.println(params.get("DDFSPARK_JAR"));
+    LOG.info(System.getProperty("spark.serializer"));
+    LOG.info(params.get("DDFSPARK_JAR"));
   }
 
   @Test
@@ -46,4 +61,226 @@ public class SparkDDFManagerTests extends BaseTest {
     manager.addDDF(ddf);
     Assert.assertEquals(ddf, manager.getDDF(ddf.getUUID()));
   }
+
+
+  public void testBasicCopyForS3(S3DDFManager s3DDFManager) throws DDFException {
+    // Test copy from a folder, the schema should be given.
+    LOG.info("========== testFolder/folder ==========");
+    S3DDF folderDDF = s3DDFManager.newDDF("jing-bucket", "testFolder/folder/", "year int, value int", null);
+    DDF folderSparkDDF = manager.copyFrom(folderDDF);
+    LOG.info(folderSparkDDF.sql("select * from @this", "error").getRows().toString());
+    assert(folderSparkDDF.getNumRows() == 4);
+
+    // Test copy from a folder with all json files.
+    LOG.info("========== testFolder/allJson ==========");
+    S3DDF allJsonDDF = s3DDFManager.newDDF("jing-bucket", "testFolder/allJson/", null, null);
+    DDF allJsonSparkDDF = manager.copyFrom(allJsonDDF);
+    // TODO: is it 6?
+    // assert(allJsonSparkDDF.getNumRows() == 4);
+
+    LOG.info("========== testFolder/folder/d.json ==========");
+    S3DDF jsonDDF = s3DDFManager.newDDF("adatao-test", "json/", null, null);
+    DDF jsonSparkDDF = manager.copyFrom(jsonDDF);
+    LOG.info(jsonSparkDDF.sql("select * from @this limit 5", "error").getRows().toString());
+
+
+    // Copy From a csv, the schema is not given.
+    LOG.info("========== testFolder/hasHeader.csv ==========");
+    Map<String, String> options = new HashMap<>() ;
+    options.put("header", "true");
+    S3DDF csvDDF = s3DDFManager.newDDF("jing-bucket", "testFolder/hasHeader.csv", null, options);
+    DDF csvSparkDDF = manager.copyFrom(csvDDF);
+    LOG.info(csvSparkDDF.sql("select * from @this", "error").getRows().toString());
+    assert(csvSparkDDF.getNumRows()==2);
+
+
+    // Copy From a csv, the schema is not given, and has no header.
+    LOG.info("========== testFolder/noHeader.csv ==========");
+    S3DDF csvDDF2 = s3DDFManager.newDDF("jing-bucket", "testFolder/noHeader.csv", null, null);
+    DDF csvSparkDDF2= manager.copyFrom(csvDDF2);
+    LOG.info(csvSparkDDF2.sql("select * from @this", "error").getRows().toString());
+    assert(csvSparkDDF2.getNumRows()==2);
+
+    // Copy From a csv, the schema is given and has no header.
+    LOG.info("========== testFolder/noHeader.csv ==========");
+    S3DDF csvDDF3 = s3DDFManager.newDDF("jing-bucket", "testFolder/noHeader.csv", "year int, val string", null);
+    DDF csvSparkDDF3 = manager.copyFrom(csvDDF3);
+    LOG.info(csvSparkDDF3.sql("select * from @this", "error").getRows().toString());
+    assert (csvSparkDDF3.getNumRows()==2);
+
+
+    LOG.info("========== tsv ==========");
+    S3DDF tsvDDF = s3DDFManager.newDDF("adatao-sample-data", "test/tsv/noheader/results.tsv", "ID int, FlagTsunami " +
+        "string, Year int, " +
+        "Month int, Day int, Hour int, Minute int, Second double, FocalDepth int, EqPrimary double, EqMagMw double, EqMagMs double, EqMagMb double, EqMagMl double, EqMagMfd double, EqMagUnk double, Intensity int, Country string, State string, LocationName string, Latitude double, Longitude double, RegionCode int, Death int, DeathDescription int, Injuries int, InjuriesDescription int", null);
+    // TODO: Check the file?
+    /*
+    DDF tsvSparkDDF = sparkDDFManager.copyFrom(tsvDDF);
+    LOG.info(tsvSparkDDF.sql("select * from @this", "error").getRows().toString());
+    assert (tsvSparkDDF.getNumRows()> 0);
+    */
+
+    LOG.info("========== pqt ==========");
+    S3DDF pqtDDF = s3DDFManager.newDDF("adatao-sample-data", "test/parquet/sleep_parquet/", null, null);
+    DDF pqtSparkDDF = manager.copyFrom(pqtDDF);
+    LOG.info(pqtSparkDDF.sql("select * from @this limit 5", "error").getRows().toString());
+    LOG.info("========== avro ==========");
+    //S3DDF avroDDF = s3DDFManager.newDDF("adatao-sample-data", "test/avro/partition/", null, null);
+    //DDF avroSparkDDF = manager.copyFrom(avroDDF);
+    //LOG.info(avroSparkDDF.sql("select * from @this limit 5", "error").getRows().toString());
+
+    // s3 doesn't work with orc now
+    /*
+    LOG.info("========== orc ==========");
+    S3DDF orcDDF = s3DDFManager.newDDF("adatao-sample-data", "test/orc/", null);
+    DDF orcSparkDDF = sparkDDFManager.copyFrom(orcDDF);
+    LOG.info(orcSparkDDF.sql("select * from @this limit 5", "error").getRows().toString());
+    */
+
+    // empty files doesn't work now
+    /*
+    LOG.info("========= empty files =========");
+    S3DDF emptyDDF = s3DDFManager.newDDF("adatao-sample-data", "test_empty_files/",
+        "val1 string, val2 string, val3 string, val4 string, val5 string, val6 string," +
+            "val7 string, val8 string, val9 string, val10 string, val11 string, val12 string, val13 string", null);
+    DDF emptySparkDDF = sparkDDFManager.copyFrom(emptyDDF);
+    LOG.info(emptySparkDDF.sql("select * from @this limit 5", "error").getRows().toString());
+    */
+  }
+
+  public void testOptions(S3DDFManager s3DDFManager) throws DDFException {
+    testComment(s3DDFManager);
+    testDelim(s3DDFManager);
+    testEscape(s3DDFManager);
+    testQuote(s3DDFManager);
+    testNull(s3DDFManager);
+  }
+
+  public void testDelim(S3DDFManager s3DDFManager) throws DDFException {
+    final Map<String, String> delim2pathMap = ImmutableMap.<String, String>builder()
+        .put(" ", "adatao-sample-data/test/extra/delim/space/")
+        .put("|", "adatao-sample-data/test/extra/delim/vertical-bar/")
+        .put("\u0001", "adatao-sample-data/test/extra/delim/ctra/")
+        .build();
+    Map<String, String> options = new HashMap<>();
+    for (Map.Entry<String, String> entry: delim2pathMap.entrySet()) {
+      options.clear();
+      options.put("delimiter", entry.getKey());
+      S3DDF s3DDF = s3DDFManager.newDDF(entry.getValue(), options);
+      DDF sparkDDF = manager.copyFrom(s3DDF);
+      assert (sparkDDF.getNumColumns() == 3);
+    }
+  }
+
+  public void testQuote(S3DDFManager s3DDFManager) {
+
+  }
+
+  public void testEscape(S3DDFManager s3DDFManager) {
+
+  }
+
+  public void testComment(S3DDFManager s3DDFManager) {
+  }
+
+  public void testNull(S3DDFManager s3DDFManager) throws DDFException {
+    final Map<String, String> nullvalue2pathMap = ImmutableMap.<String, String>builder()
+        .put("<null>", "adatao-sample-data/test/extra/nullvalue/null-using-null/null-using-flashn")
+        .put("/N", "adatao-sample-data/test/extra/nullvalue/null-using-fslashn/null-using-flashn")
+        .put("\\n", "adatao-sample-data/test/extra/nullvalue/null-using-newline/null-using-flashn")
+        .build();
+    Map<String, String> options = new HashMap<>();
+    for (Map.Entry<String, String> entry: nullvalue2pathMap.entrySet()) {
+      options.clear();
+      options.put("nullvalue", entry.getKey());
+      S3DDF s3DDF = s3DDFManager.newDDF(entry.getValue(), options);
+      DDF sparkDDF = manager.copyFrom(s3DDF);
+      assert (sparkDDF.getNumRows() > 0);
+    }
+  }
+
+
+  @Test
+  public void testCopyFromS3() throws DDFException {
+    LOG = LoggerFactory.getLogger(SparkDDFManagerTests.class);
+    S3DataSourceDescriptor s3dsd = null;
+    try {
+      s3dsd = new S3DataSourceDescriptor(new S3DataSourceURI(""),
+          new S3DataSourceCredentials(System.getenv("AWS_ACCESS_KEY_ID"), System.getenv("AWS_SECRET_ACCESS_KEY")),
+          null,
+          null);
+    } catch (URISyntaxException e) {
+      throw new DDFException(e);
+    }
+    S3DDFManager s3DDFManager= (S3DDFManager) DDFManager.get(DDFManager.EngineType.S3, s3dsd);
+    //testBasicCopyForS3(s3DDFManager);
+    testOptions(s3DDFManager);
+  }
+
+  @Test
+  public void testCopyFromHDFS() throws DDFException {
+    LOG = LoggerFactory.getLogger(SparkDDFManagerTests.class);
+    HDFSDDFManager hdfsDDFManager = new HDFSDDFManager(System.getenv("HDFS_URI"));
+    SparkDDFManager sparkDDFManager = (SparkDDFManager) manager;
+
+    // Test copy from a folder, the schema should be given.
+    LOG.info("========== test_pe/csv/small ==========");
+    HDFSDDF folderDDF = hdfsDDFManager.newDDF("/test_pe/csv/small/", "year int, value int", null);
+    DDF folderSparkDDF = sparkDDFManager.copyFrom(folderDDF);
+    LOG.info(folderSparkDDF.sql("select * from @this", "error").getRows().toString());
+    assert(folderSparkDDF.getNumRows() == 4);
+
+    // Test copy from a folder with all json files.
+    LOG.info("========== test_pe/json/single ==========");
+    HDFSDDF jsonDDF = hdfsDDFManager.newDDF("/test_pe/json/single/flat_sleep_data.json", null, null);
+    DDF jsonSparkDDF = sparkDDFManager.copyFrom(jsonDDF);
+    assert(jsonSparkDDF.getNumRows() > 0);
+
+    // Copy From a json, the schema should already be included in the json.
+    /* check the hdfs files
+    LOG.info("========== test_pe/json/multiple  ==========");
+    HDFSDDF allJsonDDF = hdfsDDFManager.newDDF("/test_pe/json/multiple", null, null);
+    DDF allJsonSparkDDF = sparkDDFManager.copyFrom(allJsonDDF);
+    LOG.info(allJsonSparkDDF.sql("select * from @this", "error").getRows().toString());
+    // assert (allJsonSparkDDF.getNumRows() > 0);
+    */
+
+
+    // Copy From a csv, the schema is not given, and has no header.
+    LOG.info("========== test_pe/csv/noheader/crime.csv ==========");
+    HDFSDDF csvDDF2 = hdfsDDFManager.newDDF("/test_pe/csv/noheader/crime.csv", null);
+    DDF csvSparkDDF2= sparkDDFManager.copyFrom(csvDDF2);
+    LOG.info(csvSparkDDF2.sql("select * from @this", "error").getRows().toString());
+    assert(csvSparkDDF2.getNumRows()==2);
+
+    // Copy From a csv, the schema is given and has no header.
+    LOG.info("========== test_pe/csv/noheader/crime.csv ==========");
+    String crimeSchema = "ID int, CaseNumber string, Date string, Block string, IUCR string, PrimaryType string, " +
+        "Description string, LocationDescription string, Arrest boolean, Domestic boolean, Beat int, District int, " +
+        "Ward int, CommunityArea int, FBICode string, XCoordinate int, YCoordinate int, Year int, UpdatedOn string, " +
+        "Latitude double, Longitude double, Location string";
+    HDFSDDF csvDDF3 = hdfsDDFManager.newDDF("/test_pe/csv/noheader/crime.csv", crimeSchema, null);
+    DDF csvSparkDDF3 = sparkDDFManager.copyFrom(csvDDF3);
+    LOG.info(csvSparkDDF3.sql("select * from @this", "error").getRows().toString());
+    assert (csvSparkDDF3.getNumRows() > 0);
+
+
+    LOG.info("========== pqt ==========");
+    HDFSDDF pqtDDF = hdfsDDFManager.newDDF("/test_pe/parquet/default", null, null);
+    DDF pqtSparkDDF = sparkDDFManager.copyFrom(pqtDDF);
+    LOG.info(pqtSparkDDF.sql("select * from @this limit 5", "error").getRows().toString());
+    assert (pqtSparkDDF.getNumRows() > 0);
+
+    LOG.info("========== avro ==========");
+    HDFSDDF avroDDF = hdfsDDFManager.newDDF("/test_pe/avro/partition", null, null);
+    DDF avroSparkDDF = sparkDDFManager.copyFrom(avroDDF);
+    LOG.info(avroSparkDDF.sql("select * from @this limit 5", "error").getRows().toString());
+    assert (avroSparkDDF.getNumRows() > 0);
+
+    LOG.info("========== orc ==========");
+    HDFSDDF orcDDF = hdfsDDFManager.newDDF("/test_pe/orc/default/", null, null);
+    DDF orcSparkDDF = sparkDDFManager.copyFrom(orcDDF);
+    assert (orcSparkDDF.getNumRows() > 0);
+  }
+
 }

--- a/spark/src/test/scala/io/ddf/spark/analytics/AggregationHandlerSuite.scala
+++ b/spark/src/test/scala/io/ddf/spark/analytics/AggregationHandlerSuite.scala
@@ -49,10 +49,10 @@ class AggregationHandlerSuite extends ATestSuite {
     val ddf = manager.sql2ddf("select * from airline", "SparkSQL").asInstanceOf[SparkDDF]
 
     val thrown1 = intercept[DDFException]{ddf.groupBy(List("Year").asJava, List("substring('aaaa')").asJava)}
-    assert(thrown1.getMessage === "No matching method for class org.apache.hadoop.hive.ql.udf.UDFSubstr with (string). Possible choices: _FUNC_(binary, int)  _FUNC_(binary, int, int)  _FUNC_(string, int)  _FUNC_(string, int, int)")
+    assert(thrown1.getMessage.contains("No matching method for class org.apache.hadoop.hive.ql.udf.UDFSubstr with (string). Possible choices: _FUNC_(binary, int)  _FUNC_(binary, int, int)  _FUNC_(string, int)  _FUNC_(string, int, int)"))
 
     val thrown2 = intercept[DDFException]{ddf.groupBy(List("Year").asJava, List("to_utc_timestamp(1,1,1)").asJava)}
-    assert(thrown2.getMessage === "The function to_utc_timestamp requires two argument, got 3")
+    assert(thrown2.getMessage.contains("The function to_utc_timestamp requires two argument, got 3"))
   }
 
   test("Proper error message for expressions or columns that contain invalid characters") {


### PR DESCRIPTION
### Description
Add S3 exploration support under S3DDFManager
Add HDFS exploration support under HDFSDDFManager
Add file format support for avro and orc
To enable the loading test for hdfs, we need to set an hdfs with desired data path, currently test tag is removed for that function.

Reviewers: @lebinh @Huandao0812 @nhanitvn @hai-adatao @sameerp @mbbui 

### How to test
Unit test.

### PR Progress
Make sure all checkboxes below are checked before merged
- [x] Branch is in format `prefix/description` (e.g: `fix/cast-type`)
- [x] Pull Request name is in format `[x-xxxx] Add rename API` (or `[No JIRA]`)
- [x] Code review is done. Merge check has no conflicts. PR checks passed