### PR TITLE
Separate New column names and transform expressions in TransformSQL

### DIFF
--- a/core/src/main/java/io/ddf/etl/IHandleTransformations.java
+++ b/core/src/main/java/io/ddf/etl/IHandleTransformations.java
@@ -38,6 +38,8 @@ public interface IHandleTransformations extends IHandleDDFFunctionalGroup {
    * Create new columns or overwrite existing ones
    *
    * @param newColumnNames Array of new column names.
+   *                       Empty or null entries in this array
+   *                       will be set to c0, c1, c2, etc..
    * @param transformExpressions array of transform expressions. Has to have the same length
    *                             with newColumnNames.
    * @param selectedColumns list of column names to be included in the result DDF.

--- a/core/src/main/java/io/ddf/etl/IHandleTransformations.java
+++ b/core/src/main/java/io/ddf/etl/IHandleTransformations.java
@@ -8,18 +8,18 @@ import java.util.List;
 
 public interface IHandleTransformations extends IHandleDDFFunctionalGroup {
 
-  public DDF transformScaleMinMax() throws DDFException;
+  DDF transformScaleMinMax() throws DDFException;
 
-  public DDF transformScaleStandard() throws DDFException;
+  DDF transformScaleStandard() throws DDFException;
 
-  public DDF transformNativeRserve(String transformExpression);
+  DDF transformNativeRserve(String transformExpression);
 
-  public DDF transformNativeRserve(String[] transformExpression);
+  DDF transformNativeRserve(String[] transformExpression);
 
-  public DDF transformPython(String[] transformFunctions, String[] functionNames,
+  DDF transformPython(String[] transformFunctions, String[] functionNames,
       String[] destColumns, String[][] sourceColumns);
 
-  public DDF transformMapReduceNative(String mapFuncDef, String reduceFuncDef, boolean mapsideCombine);
+  DDF transformMapReduceNative(String mapFuncDef, String reduceFuncDef, boolean mapsideCombine);
 
   /**
    * Create new columns or overwrite existing ones
@@ -29,16 +29,32 @@ public interface IHandleTransformations extends IHandleDDFFunctionalGroup {
    * @param columns
    * @return
    * @throws DDFException
+   * @deprecated use {@link #transformUDFWithNames(String[], String[], String[])} instead.
    */
-  public DDF transformUDF(List<String> transformExpressions, List<String> columns) throws DDFException;
+  @Deprecated
+  DDF transformUDF(List<String> transformExpressions, List<String> columns) throws DDFException;
 
-  public DDF flattenDDF(String[] columns) throws DDFException;
+  /**
+   * Create new columns or overwrite existing ones
+   *
+   * @param newColumnNames Array of new column names.
+   * @param transformExpressions array of transform expressions. Has to have the same length
+   *                             with newColumnNames.
+   * @param selectedColumns list of column names to be included in the result DDF.
+   *                        If null or empty, all existing columns will be included.
+   * @return current DDF if it is mutable, or a new DDF otherwise.
+   * @throws DDFException
+   */
+  DDF transformUDFWithNames(String[] newColumnNames, String[] transformExpressions,
+      String[] selectedColumns) throws DDFException;
 
-  public DDF flattenDDF() throws DDFException;
+  DDF flattenDDF(String[] columns) throws DDFException;
 
-  public DDF flattenArrayTypeColumn(String colName) throws DDFException;
+  DDF flattenDDF() throws DDFException;
 
-  public DDF factorIndexer(List<String> columns) throws DDFException;
+  DDF flattenArrayTypeColumn(String colName) throws DDFException;
 
-  public DDF inverseFactorIndexer(List<String> columns) throws DDFException;
+  DDF factorIndexer(List<String> columns) throws DDFException;
+
+  DDF inverseFactorIndexer(List<String> columns) throws DDFException;
 }

--- a/core/src/main/java/io/ddf/etl/TransformationHandler.java
+++ b/core/src/main/java/io/ddf/etl/TransformationHandler.java
@@ -231,6 +231,8 @@ public class TransformationHandler extends ADDFFunctionalGroupHandler implements
    * Create new columns or overwrite existing ones
    *
    * @param newColumnNames       Array of new column names.
+   *                             Empty or null entries in this array
+   *                             will be set to c0, c1, c2, etc..
    * @param transformExpressions array of transform expressions. Has to have the same length
    *                             with newColumnNames.
    * @param selectedColumns      list of column names to be included in the result DDF.

--- a/core/src/main/java/io/ddf/facades/TransformFacade.java
+++ b/core/src/main/java/io/ddf/facades/TransformFacade.java
@@ -101,6 +101,22 @@ public class TransformFacade implements IHandleTransformations {
     return transformUDF(transformExpression, null);
   }
 
+  /**
+   * Create new columns or overwrite existing ones
+   *
+   * @param newColumnNames Array of new column names.
+   * @param transformExpressions array of transform expressions. Has to have the same length
+   *                             with newColumnNames.
+   * @param selectedColumns list of column names to be included in the result DDF.
+   *                        If null or empty, all existing columns will be included.
+   * @return current DDF if it is mutable, or a new DDF otherwise.
+   * @throws DDFException
+   */
+  public DDF transformUDFWithNames(String[] newColumnNames, String[] transformExpressions,
+      String[] selectedColumns) throws DDFException {
+    return mTransformationHandler.transformUDFWithNames(newColumnNames, transformExpressions, selectedColumns);
+  }
+
   public DDF flattenDDF(String[] columns) throws DDFException {
     return flattenDDF(columns);
   }

--- a/spark/src/test/java/io/ddf/spark/etl/TransformationHandlerTest.java
+++ b/spark/src/test/java/io/ddf/spark/etl/TransformationHandlerTest.java
@@ -231,6 +231,29 @@ public class TransformationHandlerTest extends BaseTest {
         TransformationHandler.RToSqlUdf("dt=regexp_extract('hh:mm:ss', '.*\\\\+([^+])+', 1)"));
   }
 
+  @Test
+  public void  testTransformSqlWithNames() throws DDFException {
+    ddf.setMutable(true);
+    ddf = ddf.Transform.transformUDFWithNames(new String[] {"dist"}, new String[] {"round(distance/2, 2)"}, null);
+
+    Assert.assertEquals(31, ddf.getNumRows());
+    Assert.assertEquals(9, ddf.getNumColumns());
+    Assert.assertEquals("dist", ddf.getColumnName(8));
+    Assert.assertEquals(9, ddf.VIEWS.head(1).get(0).split("\\t").length);
+
+    ddf.Transform.transformUDFWithNames(new String[] {null}, new String[] {"arrtime-deptime"}, null);
+    Assert.assertEquals(31, ddf.getNumRows());
+    Assert.assertEquals(10, ddf.getNumColumns());
+    Assert.assertEquals(10, ddf.getSummary().length);
+
+    try {
+      ddf.Transform.transformUDFWithNames(new String[] {null}, new String[] {"arrtime-deptime"},
+          new String[]{"notexistedColumn"});
+      Assert.fail("Should throw exception when selecting non-existing columns");
+    } catch (DDFException ex) {
+    }
+  }
+
   @Test(expected = RuntimeException.class)
   public void testConflictingColumnDefinitions() throws DDFException {
     ddf.setMutable(true);


### PR DESCRIPTION
### Description and related tickets, documents
- Added transformUDFWithNames to replace transformUDF. Separating names and transformation expressions
- Deprecated transformUDF (in `IHandleTransformations`)

Reviewers: @Huandao0812 @nhanitvn @hai-adatao 

### Breaking changes & backward compatible issues
No

### How to test
UT

### PR Progress
Make sure all checkboxes below are checked before merged
- [x] Branch is in format `prefix/description` (see [this](http://www.guyroutledge.co.uk/blog/git-branch-naming-conventions/))
- [x] Merge check has no conflicts. PR checks passed.
- [x] Code review is done. 

