### PR TITLE
[PE-1859] Fix filesystem closed exception

### DIFF
--- a/core/src/main/java/io/ddf/util/Utils.java
+++ b/core/src/main/java/io/ddf/util/Utils.java
@@ -9,14 +9,14 @@ import io.ddf.datasource.DataFormat;
 import io.ddf.exception.DDFException;
 import org.apache.commons.io.IOUtils;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.fs.*;
+import org.apache.hadoop.fs.FileSystem;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.*;
 import java.lang.reflect.Constructor;
-  import java.lang.reflect.Method;
+import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.math.BigDecimal;
@@ -235,38 +235,24 @@ public class Utils {
   }
 
   public static String readFromFile(String fileName) throws IOException {
-    Reader reader = null;
     Configuration configuration = getConfiguration();
-    try {
-      FileSystem hdfs = FileSystem.get(configuration);
-      FSDataInputStream inputStream = hdfs.open(new Path(fileName));
-      reader = new BufferedReader(new InputStreamReader(inputStream, "utf-8"));
+    FileSystem hdfs = FileSystem.get(configuration);
+    FSDataInputStream inputStream = hdfs.open(new Path(fileName));
+    try (Reader reader = new BufferedReader(new InputStreamReader(inputStream, "utf-8"))) {
       return IOUtils.toString(reader);
-
     } catch (IOException ex) {
-      throw new IOException(String.format("Cannot read from file %s", fileName, ex));
-
-    } finally {
-      reader.close();
+      throw new IOException(String.format("Cannot read from file %s", fileName), ex);
     }
   }
 
   public static void writeToFile(String fileName, String contents) throws IOException {
-    Writer writer = null;
     Configuration configuration =  getConfiguration();
-    try {
-      FileSystem hdfs = FileSystem.get(configuration);
-      FSDataOutputStream outputStream = hdfs.create(new Path(fileName));
-
-      writer = new BufferedWriter(new OutputStreamWriter(outputStream, "utf-8"));
+    FileSystem hdfs = FileSystem.get(configuration);
+    FSDataOutputStream outputStream = hdfs.create(new Path(fileName));
+    try (Writer writer = new BufferedWriter(new OutputStreamWriter(outputStream, "utf-8"))) {
       writer.write(contents);
-      writer.close();
-      hdfs.close();
     } catch (IOException ex) {
-      throw new IOException(String.format("Cannot write to file %s", fileName, ex));
-
-    } finally {
-      writer.close();
+      throw new IOException(String.format("Cannot write to file %s", fileName), ex);
     }
   }
 


### PR DESCRIPTION
### Description and related tickets, documents
Don't close the FileSystem instance as it is cached and shared by default.

The FileSystem instance returned by FileSystem.get is cached and shared by default, see https://github.com/apache/hadoop/blob/trunk/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java#L376-L381. Thus closing it will cause "Filesystem closed" exception on other shared instance.

Also rewrite the method to use try-with-resource instead of manually closing the Writer instance.

- https://adatao.atlassian.net/browse/PE-1859

Reviewers: @Huandao0812 

### Breaking changes & backward compatible issues
NA.

### How to test
NA.

### PR Progress
Make sure all checkboxes below are checked before merged
- [x] Branch is in format `prefix/description` (see [this](http://www.guyroutledge.co.uk/blog/git-branch-naming-conventions/))
- [x] Merge check has no conflicts. PR checks passed.
- [ ] Code review is done. 