### PR TITLE
sanitize column names for csv

### DIFF
--- a/core/src/main/java/io/ddf/DDFManager.java
+++ b/core/src/main/java/io/ddf/DDFManager.java
@@ -433,9 +433,7 @@ public abstract class DDFManager extends ALoggable implements IDDFManager, IHand
       return ddf;
 
     } catch (Exception e) {
-      throw new  DDFException(String.format(
-          "While instantiating a new %s DDF of class %s with argTypes %s and argValues %s", this.getEngine(),
-          className, Arrays.toString(argTypes), Arrays.toString(argValues)), e);
+      throw new  DDFException(e);
     }
   }
 

--- a/core/src/main/java/io/ddf/util/Utils.java
+++ b/core/src/main/java/io/ddf/util/Utils.java
@@ -69,16 +69,28 @@ public class Utils {
     }
   }
 
-
+  /**
+   * Santize the column names (Used when user try to create ddfs with given schema).
+   * Only alpha-num-dash are valid characters. And the name should begin with alpha. There should be no same names.
+   * This function will
+   * (1) replace invalid character with -
+   * (2) remove the beginning character until it's valid
+   * (3) auto-rename column names to avoid same names. 'a, _a' -> 'a, a_0'
+   * @param columnNames The column name list.
+   * @return The new column name list.
+   * @throws DDFException
+   */
   public static List<String> sanitizeColumnName(List<String> columnNames) throws DDFException {
     Preconditions.checkArgument(columnNames.size() > 0);
     List<String> ret = new ArrayList<>();
     for (String name : columnNames) {
       Preconditions.checkArgument(name.length() > 0);
+      // replace invalid characters with dash
       String dashName = name.trim().replaceAll("![0-9a-zA-Z]|\\s", "_");
       int i;
       for (i = 0; i < dashName.length(); ++i) {
         char c = name.charAt(i);
+        // remove invalid beginning character
         boolean isAlpha = ((c >= 'a' && c <= 'z') || (c >= 'A' && c <='Z'));
         if (isAlpha) {
           ret.add(dashName.substring(i));
@@ -90,6 +102,7 @@ public class Utils {
         throw new DDFException(String.format("Not valid column name: %s", name));
       }
     }
+    // rename to avoid duplication
     HashSet<String> nameSet = new HashSet<>();
     for (int i = 0; i < ret.size(); ++i) {
       String validName = ret.get(i);

--- a/core/src/main/java/io/ddf/util/Utils.java
+++ b/core/src/main/java/io/ddf/util/Utils.java
@@ -109,8 +109,8 @@ public class Utils {
       String attemptName = new String(validName);
       int j = 0;
       while (true) {
-        if (!nameSet.contains(attemptName)) {
-          nameSet.add(attemptName);
+        if (!nameSet.contains(attemptName.toLowerCase())) {
+          nameSet.add(attemptName.toLowerCase());
           ret.set(i, attemptName);
           break;
         } else {

--- a/core/src/test/java/io/ddf/util/UtilsTests.java
+++ b/core/src/test/java/io/ddf/util/UtilsTests.java
@@ -1,0 +1,44 @@
+package io.ddf.util;
+
+import io.ddf.exception.DDFException;
+
+import com.google.common.collect.ImmutableList;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+
+/**
+ * Created by jing on 4/14/16.
+ */
+public class UtilsTests {
+  @Test
+  public void testSanitizeColumnNames() throws DDFException {
+    final List<ImmutableList<String>> namesList = new ArrayList<>();
+    namesList.add(new ImmutableList.Builder<String>()
+        .add("dd2_2") // valid
+        .add("_dd2_2") // start with dash
+        .add("2dd2_2") // start with num
+        .add("@dd2_2") // start with others
+        .add("dd 22") // space
+        .add("dd 22 ") // back space
+        .build());
+
+    final List<ImmutableList<String>> expectedList = new ArrayList<>();
+    expectedList.add(new ImmutableList.Builder<String>()
+        .add("dd2_2")
+        .add("dd2_2_0")
+        .add("dd2_2_1")
+        .add("dd2_2_2")
+        .add("dd_22")
+        .add("dd_22_0")
+        .build());
+
+    for (int i = 0; i < namesList.size(); ++i) {
+      List names = namesList.get(i);
+      assert (Utils.sanitizeColumnName(names).equals(expectedList.get(i)));
+    }
+  }
+}

--- a/spark/src/test/java/io/ddf/spark/SparkDDFManagerTests.java
+++ b/spark/src/test/java/io/ddf/spark/SparkDDFManagerTests.java
@@ -11,14 +11,18 @@ import io.ddf.hdfs.HDFSDDF;
 import io.ddf.hdfs.HDFSDDFManager;
 import io.ddf.s3.S3DDF;
 import io.ddf.s3.S3DDFManager;
+import io.ddf.util.Utils;
 
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.LoggerFactory;
 
 import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -125,9 +129,37 @@ public class SparkDDFManagerTests extends BaseTest {
     DDF pqtSparkDDF = manager.copyFrom(pqtDDF);
     LOG.info(pqtSparkDDF.sql("select * from @this limit 5", "error").getRows().toString());
     LOG.info("========== avro ==========");
-    //S3DDF avroDDF = s3DDFManager.newDDF("adatao-sample-data", "test/avro/partition/", null, null);
-    //DDF avroSparkDDF = manager.copyFrom(avroDDF);
-    //LOG.info(avroSparkDDF.sql("select * from @this limit 5", "error").getRows().toString());
+    S3DDF avroDDF = s3DDFManager.newDDF("adatao-sample-data", "test/avro/partition/", null, null);
+    DDF avroSparkDDF = manager.copyFrom(avroDDF);
+    assert (avroSparkDDF.getNumRows() > 0);
+
+
+    LOG.info("========== testFolder/folder ==========");
+    final List<String> nameList = new ImmutableList.Builder<String>()
+        .add("dd2_2") // valid
+        .add("_dd2_2") // start with dash
+        .add("2dd2_2") // start with num
+        .add("@dd2_2") // start with others
+        .add("dd 22") // space
+        .add("dd 22 ") // back space
+        .build();
+
+    final List<String> expectedList = new ImmutableList.Builder<String>()
+        .add("dd2_2")
+        .add("dd2_2_0")
+        .add("dd2_2_1")
+        .add("dd2_2_2")
+        .add("dd_22")
+        .add("dd_22_0")
+        .build();
+
+    StringBuilder schema = new StringBuilder(String.format("%s int", nameList.get(0)));
+    for (int i = 1; i < nameList.size(); ++i) {
+      schema.append(String.format(", %s int", nameList.get(i)));
+    }
+    S3DDF ddf = s3DDFManager.newDDF("adatao-sample-data", "test/csv/6col.csv", schema.toString(), null);
+    DDF sparkDDF = manager.copyFrom(ddf);
+    assert (sparkDDF.getColumnNames().equals(expectedList));
 
     // s3 doesn't work with orc now
     /*

--- a/spark/src/test/java/io/ddf/spark/SparkDDFManagerTests.java
+++ b/spark/src/test/java/io/ddf/spark/SparkDDFManagerTests.java
@@ -157,7 +157,8 @@ public class SparkDDFManagerTests extends BaseTest {
     for (int i = 1; i < nameList.size(); ++i) {
       schema.append(String.format(", %s int", nameList.get(i)));
     }
-    S3DDF ddf = s3DDFManager.newDDF("adatao-sample-data", "test/csv/6col.csv", schema.toString(), null);
+    S3DDF ddf = s3DDFManager.newDDF("adatao-sample-data", "test/pa/sanitize_column_name/6col.csv", schema.toString(),
+        null);
     DDF sparkDDF = manager.copyFrom(ddf);
     assert (sparkDDF.getColumnNames().equals(expectedList));
 


### PR DESCRIPTION
### Description and related tickets, documents
Sanitize column names when loading csv

Replace invalid characters by dash _
Remove invalid beginning, e.g: _a_b_c__d_ => a_b_c__d, 1a => a
If encounter duplicated column names after above steps, add number at the end: a_b, a_b, a_b => a_b, a_b_1, a_b_2

Reviewers: @Huandao0812 @nhanitvn @hai-adatao 

### How to test
UT, client test

### PR Progress
Make sure all checkboxes below are checked before merged
- [x] Branch is in format `prefix/description` (see [this](http://www.guyroutledge.co.uk/blog/git-branch-naming-conventions/))
- [x] Merge check has no conflicts. PR checks passed.
- [ ] Code review is done. 

