### PR TITLE
Make transformUDFWithNames & castType & removeColumns return new DDF by default

### DIFF
--- a/core/src/main/java/io/ddf/DDF.java
+++ b/core/src/main/java/io/ddf/DDF.java
@@ -905,6 +905,7 @@ public abstract class DDF extends ALoggable //
     this.getMutabilityHandler().setMutable(isMutable);
   }
 
+  @Deprecated
   public boolean isMutable() {
     return this.getMutabilityHandler().isMutable();
   }

--- a/core/src/main/java/io/ddf/content/IHandleMutability.java
+++ b/core/src/main/java/io/ddf/content/IHandleMutability.java
@@ -7,8 +7,10 @@ import io.ddf.misc.IHandleDDFFunctionalGroup;
 
 public interface IHandleMutability extends IHandleDDFFunctionalGroup {
 
+  @Deprecated
   public void setMutable(boolean isMutable);
 
+  @Deprecated
   public boolean isMutable();
 
   public DDF updateInplace(DDF ddf) throws DDFException;

--- a/core/src/main/java/io/ddf/content/IHandleViews.java
+++ b/core/src/main/java/io/ddf/content/IHandleViews.java
@@ -42,7 +42,12 @@ public interface IHandleViews extends IHandleDDFFunctionalGroup {
 
   public DDF removeColumn(String columnName) throws DDFException;
 
+  public DDF removeColumn(String columnName, Boolean inPlace) throws DDFException;
+
   public DDF removeColumns(String... columnNames) throws DDFException;
 
+
   public DDF removeColumns(List<String> columnNames) throws DDFException;
+
+  public DDF removeColumns(List<String> columnNames, Boolean inPlace) throws DDFException;
 }

--- a/core/src/main/java/io/ddf/content/ViewHandler.java
+++ b/core/src/main/java/io/ddf/content/ViewHandler.java
@@ -107,6 +107,17 @@ public class ViewHandler extends ADDFFunctionalGroupHandler implements IHandleVi
   }
 
   @Override
+  public DDF removeColumn(String columnName, Boolean inPlace) throws DDFException {
+    DDF newDDF = this.removeColumn(columnName);
+    if(inPlace) {
+      this.getDDF().getMutabilityHandler().updateInplace(newDDF);
+      return this.getDDF();
+    } else {
+      return newDDF;
+    }
+  }
+
+  @Override
   public DDF removeColumns(String... columnNames) throws DDFException {
     if (columnNames == null || columnNames.length == 0) throw new DDFException("columnNames must be specified");
 
@@ -126,19 +137,29 @@ public class ViewHandler extends ADDFFunctionalGroupHandler implements IHandleVi
         throw new DDFException(String.format("Column %s does not exists", columnName));
       }
     }
-    List<String> columns = this.getDDF().getColumnNames();
 
-    for (String columnName : currentColumnNames) {
-      for (Iterator<String> it = columns.iterator();it.hasNext();) {
+    for (String columnName : columnNames) {
+      for (Iterator<String> it = currentColumnNames.iterator();it.hasNext();) {
         if (it.next().equals(columnName)) {
           it.remove();
         }
       }
     }
 
-    DDF newddf = this.project(columns);
+    DDF newddf = this.project(currentColumnNames);
     newddf.getMetaDataHandler().copyFactor(this.getDDF());
     return newddf;
+  }
+
+  @Override
+  public DDF removeColumns(List<String> columnNames, Boolean inPlace) throws DDFException {
+    DDF newDDF = this.removeColumns(columnNames);
+    if(inPlace) {
+      this.getDDF().getMutabilityHandler().updateInplace(newDDF);
+      return this.getDDF();
+    } else {
+      return newDDF;
+    }
   }
 
   // ///// Execute SQL command on the DDF ///////

--- a/core/src/main/java/io/ddf/content/ViewHandler.java
+++ b/core/src/main/java/io/ddf/content/ViewHandler.java
@@ -128,7 +128,7 @@ public class ViewHandler extends ADDFFunctionalGroupHandler implements IHandleVi
     }
     List<String> columns = this.getDDF().getColumnNames();
 
-    for (String columnName : columnNames) {
+    for (String columnName : currentColumnNames) {
       for (Iterator<String> it = columns.iterator();it.hasNext();) {
         if (it.next().equals(columnName)) {
           it.remove();
@@ -137,13 +137,8 @@ public class ViewHandler extends ADDFFunctionalGroupHandler implements IHandleVi
     }
 
     DDF newddf = this.project(columns);
-    if(this.getDDF().isMutable()) {
-      this.getDDF().updateInplace(newddf);
-      return this.getDDF();
-    } else {
-      newddf.getMetaDataHandler().copyFactor(this.getDDF());
-      return newddf;
-    }
+    newddf.getMetaDataHandler().copyFactor(this.getDDF());
+    return newddf;
   }
 
   // ///// Execute SQL command on the DDF ///////

--- a/core/src/main/java/io/ddf/etl/IHandleTransformations.java
+++ b/core/src/main/java/io/ddf/etl/IHandleTransformations.java
@@ -44,11 +44,28 @@ public interface IHandleTransformations extends IHandleDDFFunctionalGroup {
    *                             with newColumnNames.
    * @param selectedColumns list of column names to be included in the result DDF.
    *                        If null or empty, all existing columns will be included.
-   * @return current DDF if it is mutable, or a new DDF otherwise.
+   * @return new DDF
    * @throws DDFException
    */
   DDF transformUDFWithNames(String[] newColumnNames, String[] transformExpressions,
       String[] selectedColumns) throws DDFException;
+
+  /**
+   * Create new columns or overwrite existing ones
+   *
+   * @param newColumnNames Array of new column names.
+   *                       Empty or null entries in this array
+   *                       will be set to c0, c1, c2, etc..
+   * @param transformExpressions array of transform expressions. Has to have the same length
+   *                             with newColumnNames.
+   * @param selectedColumns list of column names to be included in the result DDF.
+   *                        If null or empty, all existing columns will be included.
+   * @param inPlace Whether to return a new DDF or modify the current DDF in place
+   * @return current DDF if it is inPlace, or a new DDF otherwise.
+   * @throws DDFException
+   */
+  DDF transformUDFWithNames(String[] newColumnNames, String[] transformExpressions,
+      String[] selectedColumns, Boolean inPlace) throws DDFException;
 
   DDF flattenDDF(String[] columns) throws DDFException;
 
@@ -61,4 +78,23 @@ public interface IHandleTransformations extends IHandleDDFFunctionalGroup {
   DDF inverseFactorIndexer(List<String> columns) throws DDFException;
 
   DDF oneHotEncoding(String inputColumn, String outputColumnName) throws DDFException;
+
+  /**
+   * Cast a column to newType
+   * @param column name of column to be casted
+   * @param newType type of new column
+   * @return a new DDF
+   * @throws DDFException
+   */
+  DDF castType(String column, String newType) throws DDFException;
+
+  /**
+   * Cast a column to newType
+   * @param column name of column to be casted
+   * @param newType type of new column
+   * @param inplace if true modify the DDF, else return new DDF
+   * @return the current DDF if inplace is true, else return new DDF
+   * @throws DDFException
+   */
+  DDF castType(String column, String newType, Boolean inPlace) throws DDFException;
 }

--- a/core/src/main/java/io/ddf/etl/IHandleTransformations.java
+++ b/core/src/main/java/io/ddf/etl/IHandleTransformations.java
@@ -17,7 +17,10 @@ public interface IHandleTransformations extends IHandleDDFFunctionalGroup {
   DDF transformNativeRserve(String[] transformExpression);
 
   DDF transformPython(String[] transformFunctions, String[] functionNames,
-      String[] destColumns, String[][] sourceColumns);
+      String[] destColumns, String[][] sourceColumns) throws DDFException;
+
+  DDF transformPython(String[] transformFunctions, String[] functionNames,
+      String[] destColumns, String[][] sourceColumns, Boolean inPlace) throws DDFException;
 
   DDF transformMapReduceNative(String mapFuncDef, String reduceFuncDef, boolean mapsideCombine);
 

--- a/core/src/main/java/io/ddf/etl/TransformationHandler.java
+++ b/core/src/main/java/io/ddf/etl/TransformationHandler.java
@@ -124,13 +124,8 @@ public class TransformationHandler extends ADDFFunctionalGroupHandler implements
     newCols.setLength(newCols.length() - 1);
     String sqlCmd = String.format("SELECT *, %s FROM @this", newCols.toString());
     DDF newddf = this.getDDF().sql2ddf(sqlCmd);
-
-    if (this.getDDF().isMutable()) {
-      return this.getDDF().updateInplace(newddf);
-    } else {
-      newddf.getMetaDataHandler().copyFactor(this.getDDF());
-      return newddf;
-    }
+    newddf.getMetaDataHandler().copyFactor(this.getDDF());
+    return newddf;
   }
 
   public synchronized DDF transformUDF(String RExprs, List<String> columns) throws DDFException {
@@ -344,15 +339,19 @@ public class TransformationHandler extends ADDFFunctionalGroupHandler implements
 
     DDF newddf = this.getManager()
         .sql2ddf(sqlCmd, new SQLDataSourceDescriptor(sqlCmd, null, null, null, this.getDDF().getUUID().toString()));
-
-    if (this.getDDF().isMutable()) {
-      return this.getDDF().updateInplace(newddf);
-    } else {
-      newddf.getMetaDataHandler().copyFactor(this.getDDF());
-      return newddf;
-    }
+    newddf.getMetaDataHandler().copyFactor(this.getDDF());
+    return newddf;
   }
 
+  public DDF transformUDFWithNames(String[] newColumnNames, String[] transformExpressions,
+      String[] selectedColumns, Boolean inPlace) throws DDFException {
+    if(inPlace) {
+      DDF newDDF = transformUDFWithNames(newColumnNames, transformExpressions, selectedColumns);
+      return this.getDDF().updateInplace(newDDF);
+    } else {
+      return transformUDFWithNames(newColumnNames, transformExpressions, selectedColumns);
+    }
+  }
   public static String RToSqlUdf(List<String> RExp) {
     return RToSqlUdf(RExp, null, null);
   }
@@ -373,5 +372,18 @@ public class TransformationHandler extends ADDFFunctionalGroupHandler implements
 
   @Override public DDF oneHotEncoding(String inputColumn, String outputColumnName) throws DDFException {
     throw new UnsupportedOperationException();
+  }
+
+  @Override public DDF castType(String column, String newType) throws DDFException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override public DDF castType(String column, String newType, Boolean inPlace) throws DDFException {
+    if (inPlace) {
+      DDF ddf = castType(column, newType);
+      return this.getDDF().updateInplace(ddf);
+    } else {
+      return castType(column, newType);
+    }
   }
 }

--- a/core/src/main/java/io/ddf/etl/TransformationHandler.java
+++ b/core/src/main/java/io/ddf/etl/TransformationHandler.java
@@ -78,23 +78,25 @@ public class TransformationHandler extends ADDFFunctionalGroupHandler implements
 
   }
 
-  public DDF transformNativeRserve(String transformExpression) {
-    // TODO Auto-generated method stub
+  @Override public DDF transformNativeRserve(String transformExpression) {
     return null;
   }
 
-  public DDF transformNativeRserve(String[] transformExpressions) {
+  @Override public DDF transformNativeRserve(String[] transformExpressions) {
     return null;
   }
 
-  public DDF transformPython(String[] transformFuctions, String[] functionNames, String[] destColumns,
-      String[][] sourceColumns) {
-    // TODO Auto-generated method stub
+  @Override public DDF transformPython(String[] transformFuctions, String[] functionNames, String[] destColumns,
+      String[][] sourceColumns) throws DDFException {
+    return null;
+  }
+
+  @Override public DDF transformPython(String[] transformFuctions, String[] functionNames, String[] destColumns,
+      String[][] sourceColumns, Boolean inPlace) throws DDFException {
     return null;
   }
 
   @Override public DDF transformMapReduceNative(String mapFuncDef, String reduceFuncDef, boolean mapsideCombine) {
-    // TODO Auto-generated method stub
     return null;
   }
 

--- a/core/src/main/java/io/ddf/facades/TransformFacade.java
+++ b/core/src/main/java/io/ddf/facades/TransformFacade.java
@@ -60,8 +60,15 @@ public class TransformFacade implements IHandleTransformations {
 
   @Override
   public DDF transformPython(String[] transformFunctions, String[] functionNames,
-      String[] destColumns, String[][] sourceColumns) {
+      String[] destColumns, String[][] sourceColumns) throws DDFException {
     return mTransformationHandler.transformPython(transformFunctions, functionNames, destColumns, sourceColumns);
+  }
+
+  @Override
+  public DDF transformPython(String[] transformFunctions, String[] functionNames,
+      String[] destColumns, String[][] sourceColumns, Boolean inPlace) throws DDFException {
+    return mTransformationHandler.transformPython(transformFunctions, functionNames, destColumns,
+        sourceColumns, inPlace);
   }
 
   @Override

--- a/core/src/main/java/io/ddf/facades/TransformFacade.java
+++ b/core/src/main/java/io/ddf/facades/TransformFacade.java
@@ -117,6 +117,11 @@ public class TransformFacade implements IHandleTransformations {
     return mTransformationHandler.transformUDFWithNames(newColumnNames, transformExpressions, selectedColumns);
   }
 
+  public DDF transformUDFWithNames(String[] newColumnNames, String[] transformExpressions,
+      String[] selectedColumns, Boolean inPlace) throws DDFException {
+    return mTransformationHandler.transformUDFWithNames(newColumnNames, transformExpressions, selectedColumns, inPlace);
+  }
+
   public DDF flattenDDF(String[] columns) throws DDFException {
     return flattenDDF(columns);
   }
@@ -139,5 +144,13 @@ public class TransformFacade implements IHandleTransformations {
 
   public DDF oneHotEncoding(String inputColumn, String outputColumnName) throws DDFException {
     return mTransformationHandler.oneHotEncoding(inputColumn, outputColumnName);
+  }
+
+  public DDF castType(String column, String newType) throws DDFException {
+    return mTransformationHandler.castType(column, newType);
+  }
+
+  public DDF castType(String column, String newType, Boolean inPlace) throws DDFException {
+    return mTransformationHandler.castType(column, newType, inPlace);
   }
 }

--- a/core/src/main/java/io/ddf/facades/ViewsFacade.java
+++ b/core/src/main/java/io/ddf/facades/ViewsFacade.java
@@ -88,6 +88,11 @@ public class ViewsFacade implements IHandleViews {
   }
 
   @Override
+  public DDF removeColumn(String columnName, Boolean inPlace) throws DDFException {
+    return this.getViewHandler().removeColumn(columnName, inPlace);
+  }
+
+  @Override
   public DDF removeColumns(String... columnNames) throws DDFException {
     return this.getViewHandler().removeColumns(columnNames);
   }
@@ -95,5 +100,10 @@ public class ViewsFacade implements IHandleViews {
   @Override
   public DDF removeColumns(List<String> columnNames) throws DDFException {
     return this.getViewHandler().removeColumns(columnNames);
+  }
+
+  @Override
+  public DDF removeColumns(List<String> columnNames, Boolean inPlace) throws DDFException {
+    return this.getViewHandler().removeColumns(columnNames, inPlace);
   }
 }

--- a/core/src/main/java/io/ddf/util/Utils.java
+++ b/core/src/main/java/io/ddf/util/Utils.java
@@ -641,4 +641,13 @@ public class Utils {
     }
   }
 
+  /**
+   * Find if there exists any element in collection that is equal to item, ignoring character case
+   * @param collection collection of strings
+   * @param item the string to look for
+   * @return true if there is an element equal to item, ignoring case
+   */
+  public static boolean containsIgnoreCase(Collection<String> collection, String item) {
+    return collection.stream().anyMatch(c -> c.equalsIgnoreCase(item));
+  }
 }

--- a/spark/src/main/scala/io/ddf/spark/etl/TransformationHandler.scala
+++ b/spark/src/main/scala/io/ddf/spark/etl/TransformationHandler.scala
@@ -313,6 +313,12 @@ class TransformationHandler(mDDF: DDF) extends CoreTransformationHandler(mDDF) {
     val encodedDF = encoder.transform(df)
     this.getManager.asInstanceOf[SparkDDFManager].newDDFFromSparkDataFrame(encodedDF)
   }
+
+  override def castType(column: String, newType: String): DDF = {
+    val df = this.mDDF.getRepresentationHandler.get(classOf[DataFrame]).asInstanceOf[DataFrame]
+    val newDF = df.withColumn(column , df.col(column).cast(newType))
+    this.getManager.asInstanceOf[SparkDDFManager].newDDFFromSparkDataFrame(newDF)
+  }
 }
 
 object TransformationHandler {

--- a/spark/src/main/scala/io/ddf/spark/etl/TransformationHandler.scala
+++ b/spark/src/main/scala/io/ddf/spark/etl/TransformationHandler.scala
@@ -234,13 +234,20 @@ class TransformationHandler(mDDF: DDF) extends CoreTransformationHandler(mDDF) {
         @tailrec
         def getNewColName(c: Int): Int = {
           val cn = s"c$c"
-          if (!setExistingColumns.contains(cn) && !newNamedColumns.contains(cn)) {
+          if (!setExistingColumns.exists(cn.equalsIgnoreCase)
+            && !newNamedColumns.exists(cn.equalsIgnoreCase)) {
             return c
           }
           getNewColName(c + 1)
         }
         s"c${getNewColName(0)}"
-      case colName => colName
+      case colName =>
+        if (setExistingColumns.exists(colName.equalsIgnoreCase)
+          || newNamedColumns.count(colName.equalsIgnoreCase) > 1) {
+          throw new DDFException(s"Duplicated column name: $colName. " +
+            s"Please use another name for the column.")
+        }
+        colName
     }
     val dfrdd = mDDF.getRepresentationHandler.get(classOf[RDD[_]], classOf[PyObject]).asInstanceOf[RDD[PyObject]]
 
@@ -304,6 +311,20 @@ class TransformationHandler(mDDF: DDF) extends CoreTransformationHandler(mDDF) {
     mLog.info(">>>>> adding ddf to manager: " + ddf.getName)
     ddf.getMetaDataHandler.copyFactor(this.getDDF)
     ddf
+  }
+
+  /**
+    *
+    * @param transformFunctions base64-encoded marshaled bytecode of the functions
+    * @param destColumns names of the new columns
+    * @param sourceColumns names of the source columns
+    * @return
+    */
+  override def transformPython(transformFunctions: Array[String], functionNames: Array[String],
+                               destColumns: Array[String],
+                               sourceColumns: Array[Array[String]], inPlace: java.lang.Boolean): DDF = {
+    val ddf = this.transformPython(transformFunctions, functionNames, destColumns, sourceColumns)
+    if (inPlace) this.getDDF.updateInplace(ddf) else ddf
   }
 
   override def factorIndexer(columns: java.util.List[String]): DDF = {

--- a/spark/src/test/java/io/ddf/spark/content/ViewHandlerTest.java
+++ b/spark/src/test/java/io/ddf/spark/content/ViewHandlerTest.java
@@ -26,12 +26,22 @@ public class ViewHandlerTest extends BaseTest{
     columns.add("month");
     columns.add("deptime");
 
-    ddf.VIEWS.removeColumn("year");
+    DDF ddf1 = ddf.VIEWS.removeColumn("year");
+    Assert.assertEquals(28, ddf1.getNumColumns());
+    DDF ddf2 = ddf1.VIEWS.removeColumns("deptime");
+    Assert.assertEquals(27, ddf2.getNumColumns());
+    DDF ddf3 = ddf0.VIEWS.removeColumns(columns);
+    Assert.assertEquals(26, ddf3.getNumColumns());
+    Assert.assertEquals(29, ddf0.getNumColumns());
+    Assert.assertEquals(29, ddf.getNumColumns());
+
+    DDF ddf4 = ddf.VIEWS.removeColumn("year", true);
     Assert.assertEquals(28, ddf.getNumColumns());
-    ddf.VIEWS.removeColumns("deptime");
-    Assert.assertEquals(27, ddf.getNumColumns());
-    ddf0.VIEWS.removeColumns(columns);
-    Assert.assertEquals(26, ddf0.getNumColumns());
+    Assert.assertEquals(ddf, ddf4);
+
+    DDF ddf5 = ddf0.VIEWS.removeColumns(columns, true);
+    Assert.assertEquals(26, ddf5.getNumColumns());
+    Assert.assertEquals(ddf5, ddf0);
   }
 
   @Test

--- a/spark/src/test/java/io/ddf/spark/etl/TransformationHandlerTest.java
+++ b/spark/src/test/java/io/ddf/spark/etl/TransformationHandlerTest.java
@@ -281,42 +281,98 @@ public class TransformationHandlerTest extends BaseTest {
           new String[]{"notexistedColumn"});
       Assert.fail("Should throw exception when selecting non-existing columns");
     } catch (DDFException ex) {
+      Assert.assertTrue(ex.getMessage().contains("Selected column 'notexistedColumn' does not exist"));
+    }
+
+    try {
+      ddf.Transform.transformUDFWithNames(new String[] {"c100", "c100"},
+          new String[] {"round(distance/2, 2)", "arrtime-deptime"}, null);
+      Assert.fail("Should throw exception when transforming with duplicated column name");
+    } catch (DDFException ex) {
+      Assert.assertTrue(ex.getMessage().contains("Duplicated column name: c100"));
+    }
+
+    try {
+      ddf.Transform.transformUDFWithNames(new String[] {"newcolumnname", "newColumnName"},
+          new String[] {"round(distance/2, 2)", "arrtime-deptime"}, null);
+      Assert.fail("Should throw exception when transforming with duplicated column name");
+    } catch (DDFException ex) {
+      Assert.assertTrue(ex.getMessage().contains("Duplicated column name"));
+    }
+
+    try {
+      ddf.Transform.transformUDFWithNames(new String[] {"ArrTime", "newColumnName"},
+          new String[] {"round(distance/2, 2)", "arrtime-deptime"}, null);
+      Assert.fail("Should throw exception when transforming with duplicated column name");
+    } catch (DDFException ex) {
+      Assert.assertTrue(ex.getMessage().contains("Duplicated column name"));
     }
   }
 
   @Test
   public void  testTransformSqlWithNamesMutable() throws DDFException {
 
-    DDF ddf2 = ddf.Transform
-        .transformUDFWithNames(new String[] { "dist" }, new String[] { "round(distance/2, 2)" }, null, true);
-    Assert.assertEquals(ddf, ddf2);
-    Assert.assertEquals(ddf.getNumColumns(), ddf2.getNumColumns());
-    Assert.assertEquals(31, ddf2.getNumRows());
-    Assert.assertEquals(9, ddf2.getNumColumns());
-    Assert.assertEquals("dist", ddf2.getColumnName(8));
-    Assert.assertEquals(9, ddf2.VIEWS.head(1).get(0).split("\\t").length);
+    DDF ddf2 = ddf.copy();
 
-    ddf2 = ddf.Transform.transformUDFWithNames(new String[] { null }, new String[] { "arrtime-deptime" }, null, true);
+    DDF ddf3 = ddf2.Transform
+        .transformUDFWithNames(new String[] { "dist" }, new String[] { "round(distance/2, 2)" }, null, true);
+    Assert.assertEquals(ddf2, ddf3);
+    Assert.assertEquals(ddf2.getNumColumns(), ddf3.getNumColumns());
+    Assert.assertEquals(31, ddf3.getNumRows());
+    Assert.assertEquals(9, ddf3.getNumColumns());
+    Assert.assertEquals("dist", ddf3.getColumnName(8));
+    Assert.assertEquals(9, ddf3.VIEWS.head(1).get(0).split("\\t").length);
+
+    ddf2.Transform.transformUDFWithNames(new String[] { null }, new String[] { "arrtime-deptime" }, null, true);
     Assert.assertEquals(31, ddf2.getNumRows());
-    Assert.assertEquals(ddf, ddf2);
-    Assert.assertEquals(ddf.getNumColumns(), ddf2.getNumColumns());
     Assert.assertEquals(10, ddf2.getNumColumns());
     Assert.assertEquals(10, ddf2.getSummary().length);
 
+    try {
+      ddf2.Transform.transformUDFWithNames(new String[] { null, "c0" },
+          new String[] { "round(distance/2, 2)", "arrtime-deptime" }, null, true);
+      Assert.fail("Should throw exception when transforming with duplicated column name");
+    } catch (DDFException ex) {
+      Assert.assertTrue(ex.getMessage().contains("Duplicated column name"));
+    }
+
     // mixed transform with duplicated name
-    ddf2 = ddf.Transform
-        .transformUDFWithNames(new String[] { null, "c0" }, new String[] { "round(distance/2, 2)", "arrtime-deptime" },
-            null, true);
+    ddf2.Transform.transformUDFWithNames(new String[] { null, "c1" },
+        new String[] { "round(distance/2, 2)", "arrtime-deptime" }, null, true);
     Assert.assertEquals(31, ddf2.getNumRows());
-    Assert.assertEquals(11, ddf2.getNumColumns());
-    Assert.assertEquals(11, ddf2.getSummary().length);
+    Assert.assertEquals(12, ddf2.getNumColumns());
+    Assert.assertEquals(12, ddf2.getSummary().length);
 
     try {
-      ddf.Transform.transformUDFWithNames(new String[] { null }, new String[] { "arrtime-deptime" },
-          new String[] { "notexistedColumn" });
+      ddf2.Transform.transformUDFWithNames(new String[] { null }, new String[] { "arrtime-deptime" },
+          new String[] { "notexistedColumn" }, true);
       Assert.fail("Should throw exception when selecting non-existing columns");
     } catch (DDFException ex) {
-      
+      Assert.assertTrue(ex.getMessage().contains("Selected column 'notexistedColumn' does not exist"));
+    }
+
+    try {
+      ddf2.Transform.transformUDFWithNames(new String[] {"c100", "c100"},
+          new String[] {"round(distance/2, 2)", "arrtime-deptime"}, null, true);
+      Assert.fail("Should throw exception when transforming with duplicated column name");
+    } catch (DDFException ex) {
+      Assert.assertTrue(ex.getMessage().contains("Duplicated column name: c100"));
+    }
+
+    try {
+      ddf2.Transform.transformUDFWithNames(new String[] {"newcolumnname", "newColumnName"},
+          new String[] {"round(distance/2, 2)", "arrtime-deptime"}, null, true);
+      Assert.fail("Should throw exception when transforming with duplicated column name");
+    } catch (DDFException ex) {
+      Assert.assertTrue(ex.getMessage().contains("Duplicated column name"));
+    }
+
+    try {
+      ddf2.Transform.transformUDFWithNames(new String[] {"ArrTime", "newColumnName"},
+          new String[] {"round(distance/2, 2)", "arrtime-deptime"}, null, true);
+      Assert.fail("Should throw exception when transforming with duplicated column name");
+    } catch (DDFException ex) {
+      Assert.assertTrue(ex.getMessage().contains("Duplicated column name"));
     }
   }
 

--- a/spark/src/test/java/io/ddf/spark/etl/TransformationHandlerTest.java
+++ b/spark/src/test/java/io/ddf/spark/etl/TransformationHandlerTest.java
@@ -56,6 +56,45 @@ public class TransformationHandlerTest extends BaseTest {
     Assert.assertTrue(newDdf.getColumnNames().contains("c0"));
     Assert.assertTrue(newDdf.getColumnNames().contains("col2"));
     Assert.assertEquals(10, newDdf.getNumColumns());
+
+    try {
+      newDdf.Transform.transformPython(
+          new String[] {"ZGVmIHRyYW5zKHgpOgogIHJldHVybiB4LzIuCg==", "ZGVmIHRyYW5zMih4KToKICByZXR1cm4geCsxMAo="},
+          new String[] {"trans", "TrAnS2"}, new String[] {null, "col2"},
+          new String[][] {new String[] {"distance"}, new String[] {"month"}});
+      Assert.fail("Should throw error for duplicated column");
+    } catch (DDFException ex) {
+      Assert.assertTrue(ex.getMessage().contains("Duplicated column name"));
+    }
+  }
+
+  @Test
+  public void testTransformPythonInPlace() throws DDFException {
+    // f = lambda x: x/2.
+    // f = lambda x: x+10
+    DDF newDdf = ddf.copy();
+    DDF newDdf2 = newDdf.Transform.transformPython(
+        new String[] {"ZGVmIHRyYW5zKHgpOgogIHJldHVybiB4LzIuCg==", "ZGVmIHRyYW5zMih4KToKICByZXR1cm4geCsxMAo="},
+        new String[] {"trans", "trans2"},
+        new String[] {null, "col2"},
+        new String[][] { new String[] {"distance"}, new String[] {"month"}},
+        Boolean.TRUE);
+
+    Assert.assertTrue(newDdf.getUUID().equals(newDdf2.getUUID()));
+    Assert.assertNotNull(newDdf2);
+    Assert.assertTrue(newDdf2.getColumnNames().contains("c0"));
+    Assert.assertTrue(newDdf2.getColumnNames().contains("col2"));
+    Assert.assertEquals(10, newDdf2.getNumColumns());
+
+    try {
+      newDdf.Transform.transformPython(
+          new String[] {"ZGVmIHRyYW5zKHgpOgogIHJldHVybiB4LzIuCg==", "ZGVmIHRyYW5zMih4KToKICByZXR1cm4geCsxMAo="},
+          new String[] {"trans", "TrAnS2"}, new String[] {null, "col2"},
+          new String[][] {new String[] {"distance"}, new String[] {"month"}}, true);
+      Assert.fail("Should throw error for duplicated column");
+    } catch (DDFException ex) {
+      Assert.assertTrue(ex.getMessage().contains("Duplicated column name"));
+    }
   }
 
   @Test


### PR DESCRIPTION
### Description and related tickets, documents
... with option to modify the current DDF inplace

Reviewers: @phvu @nhanitvn @zkidkid @PangZhi 

### Breaking changes & backward compatible issues
Change in transformUDFWithNames & castType behaviour

### PR Progress
Make sure all checkboxes below are checked before merged
- [x] Branch is in format `prefix/description` (see [this](http://www.guyroutledge.co.uk/blog/git-branch-naming-conventions/))
- [ ] Merge check has no conflicts. PR checks passed.
- [ ] Code review is done. 
