### PR TITLE
fix regex of sanitizing

### DIFF
--- a/core/src/main/java/io/ddf/util/Utils.java
+++ b/core/src/main/java/io/ddf/util/Utils.java
@@ -86,10 +86,10 @@ public class Utils {
     for (String name : columnNames) {
       Preconditions.checkArgument(name.length() > 0);
       // replace invalid characters with dash
-      String dashName = name.trim().replaceAll("![0-9a-zA-Z]|\\s", "_");
+      String dashName = name.trim().replaceAll("[^0-9a-zA-Z]|\\s", "_");
       int i;
       for (i = 0; i < dashName.length(); ++i) {
-        char c = name.charAt(i);
+        char c = dashName.charAt(i);
         // remove invalid beginning character
         boolean isAlpha = ((c >= 'a' && c <= 'z') || (c >= 'A' && c <='Z'));
         if (isAlpha) {

--- a/spark/src/test/java/io/ddf/spark/SparkDDFManagerTests.java
+++ b/spark/src/test/java/io/ddf/spark/SparkDDFManagerTests.java
@@ -170,6 +170,23 @@ public class SparkDDFManagerTests extends BaseTest {
     DDF sparkDDF = manager.copyFrom(ddf);
     assert (sparkDDF.getColumnNames().equals(expectedList));
 
+    ddf = s3DDFManager.newDDF("adatao-sample-data", "test/pa/sanitize_column_name/6col.csv",
+        "__col1 string, col2__ string, #$@__-col3 string, col3 string, col4__a  string, a@#$@#@#!@$&*^ string",
+        null);
+    sparkDDF = manager.copyFrom(ddf);
+
+    final List<String> expectedList2 = new ImmutableList.Builder<String>()
+        .add("col1")
+        .add("col2__")
+        .add("col3")
+        .add("col3_0")
+        .add("col4__a")
+        .add("a_____________")
+        .build();
+
+    assert (sparkDDF.getColumnNames().equals(expectedList2));
+
+
     // s3 doesn't work with orc now
     /*
     LOG.info("========== orc ==========");


### PR DESCRIPTION
### Description and related tickets, documents
Fix the wrong regex of sanitizing column name

a@#$@#@#!@$&*^  -> a____________

Reviewers: @hai-adatao

### How to test
UT

### PR Progress
Make sure all checkboxes below are checked before merged
- [x] Branch is in format `prefix/description` (see [this](http://www.guyroutledge.co.uk/blog/git-branch-naming-conventions/))
- [x] Merge check has no conflicts. PR checks passed.
- [x] Code review is done. 

