### PR TITLE
Can get a DDF by sampling a Spark DDF by size

### DIFF
--- a/core/src/main/java/io/ddf/content/IHandleViews.java
+++ b/core/src/main/java/io/ddf/content/IHandleViews.java
@@ -24,11 +24,13 @@ public interface IHandleViews extends IHandleDDFFunctionalGroup {
    */
   public List<Object[]> getRandomSample(int numSamples, boolean withReplacement, int seed);
 
-  public DDF getRandomSampleByNum(int numSamples,
+  public DDF getRandomSampleByNum(long numSamples,
                                   boolean withReplacement,
                                   int seed);
 
   public DDF getRandomSample(double percent, boolean withReplacement, int seed);
+
+  public DDF getRandomSampleApprox(double percent, boolean withReplacement, int seed);
 
   public List<String> head(int numRows) throws DDFException;
 

--- a/core/src/main/java/io/ddf/content/ViewHandler.java
+++ b/core/src/main/java/io/ddf/content/ViewHandler.java
@@ -47,7 +47,6 @@ public class ViewHandler extends ADDFFunctionalGroupHandler implements IHandleVi
 
   @Override
   public DDF getRandomSample(double percent, boolean withReplacement, int seed) {
-    // TODO Auto-generated method stub
     return null;
   }
 

--- a/core/src/main/java/io/ddf/content/ViewHandler.java
+++ b/core/src/main/java/io/ddf/content/ViewHandler.java
@@ -41,13 +41,19 @@ public class ViewHandler extends ADDFFunctionalGroupHandler implements IHandleVi
   }
 
   @Override
-  public DDF getRandomSampleByNum(int numSamples, boolean withReplacement,
+  public DDF getRandomSampleByNum(long numSamples, boolean withReplacement,
                                   int seed) {
     return null;
   }
 
   @Override
   public DDF getRandomSample(double percent, boolean withReplacement, int seed) {
+    // TODO Auto-generated method stub
+    return null;
+  }
+
+  @Override
+  public DDF getRandomSampleApprox(double percent, boolean withReplacement, int seed) {
     // TODO Auto-generated method stub
     return null;
   }

--- a/core/src/main/java/io/ddf/content/ViewHandler.java
+++ b/core/src/main/java/io/ddf/content/ViewHandler.java
@@ -36,7 +36,6 @@ public class ViewHandler extends ADDFFunctionalGroupHandler implements IHandleVi
 
   @Override
   public List<Object[]> getRandomSample(int numSamples, boolean withReplacement, int seed) {
-    // TODO Auto-generated method stub
     return null;
   }
 
@@ -54,7 +53,6 @@ public class ViewHandler extends ADDFFunctionalGroupHandler implements IHandleVi
 
   @Override
   public DDF getRandomSampleApprox(double percent, boolean withReplacement, int seed) {
-    // TODO Auto-generated method stub
     return null;
   }
 

--- a/core/src/main/java/io/ddf/facades/ViewsFacade.java
+++ b/core/src/main/java/io/ddf/facades/ViewsFacade.java
@@ -43,7 +43,7 @@ public class ViewsFacade implements IHandleViews {
   }
 
   @Override
-  public DDF getRandomSampleByNum(int numSamples, boolean withReplacement,
+  public DDF getRandomSampleByNum(long numSamples, boolean withReplacement,
                                   int seed) {
     return mViewHandler.getRandomSampleByNum(numSamples, withReplacement, seed);
   }
@@ -51,6 +51,11 @@ public class ViewsFacade implements IHandleViews {
   @Override
   public DDF getRandomSample(double percent, boolean withReplacement, int seed) {
     return mViewHandler.getRandomSample(percent, withReplacement, seed);
+  }
+
+  @Override
+  public DDF getRandomSampleApprox(double percent, boolean withReplacement, int seed){
+    return mViewHandler.getRandomSampleApprox(percent, withReplacement, seed);
   }
 
   @Override

--- a/spark/src/main/scala/io/ddf/spark/content/ViewHandler.scala
+++ b/spark/src/main/scala/io/ddf/spark/content/ViewHandler.scala
@@ -117,7 +117,7 @@ class ViewHandler(mDDF: DDF) extends io.ddf.content.ViewHandler(mDDF) with IHand
       throw new IllegalArgumentException("Sampling fraction must be larger or equal to 0 in sampling with replacement")
     }
 
-    getRandomSampleByNum((fraction * mDDF.getNumRows).toLong, withReplacement, seed)
+    getRandomSampleByNum(Math.round(fraction * mDDF.getNumRows), withReplacement, seed)
 
   }
 

--- a/spark/src/main/scala/io/ddf/spark/content/ViewHandler.scala
+++ b/spark/src/main/scala/io/ddf/spark/content/ViewHandler.scala
@@ -17,6 +17,8 @@ import scala.util.Random
 import org.apache.spark.mllib.random.RandomRDDs._
 import org.apache.spark.sql.types.{LongType, StructField, StructType}
 
+import scala.collection.JavaConverters
+
 /**
   * RDD-based ViewHandler
   *
@@ -75,7 +77,9 @@ class ViewHandler(mDDF: DDF) extends io.ddf.content.ViewHandler(mDDF) with IHand
       val sampledRDD = rddRow.sample(true, 2.0 * numSamples / numRows, seed).zipWithIndex().filter(_._2 < numSamples).map(_._1)
 
       val manager = this.getManager
-      val sampleDDF = manager.newDDF(sampledRDD, Array(classOf[RDD[_]], classOf[Row]), manager.getNamespace, null, mDDF.getSchema)
+      val schema: Schema = new Schema(null,
+        JavaConverters.asScalaBufferConverter(mDDF.getSchema.getColumns).asScala.toArray)
+      val sampleDDF = manager.newDDF(sampledRDD, Array(classOf[RDD[_]], classOf[Row]), manager.getNamespace, null, schema)
 
       // Copy Factor info
       sampleDDF.getMetaDataHandler.copyFactor(mDDF)

--- a/spark/src/main/scala/io/ddf/spark/content/ViewHandler.scala
+++ b/spark/src/main/scala/io/ddf/spark/content/ViewHandler.scala
@@ -1,6 +1,6 @@
 /**
- *
- */
+  *
+  */
 package io.ddf.spark.content
 
 import io.ddf.DDF
@@ -16,11 +16,12 @@ import scala.collection.JavaConversions._
 import scala.util.Random
 import org.apache.spark.mllib.random.RandomRDDs._
 import org.apache.spark.sql.types.{LongType, StructField, StructType}
+
 /**
- * RDD-based ViewHandler
- *
- *
- */
+  * RDD-based ViewHandler
+  *
+  *
+  */
 class ViewHandler(mDDF: DDF) extends io.ddf.content.ViewHandler(mDDF) with IHandleViews {
 
   object ViewFormat extends Enumeration {
@@ -31,14 +32,14 @@ class ViewHandler(mDDF: DDF) extends io.ddf.content.ViewHandler(mDDF) with IHand
   import ViewFormat._
 
   /**
-   * Same as {@link #get(int[], int)}, but accepts a scala.Enumeration for format instead.
-   *
-   * @param columns
-   * @param format
-   * A scala.Enumeration that will be converted to an integer by calling
-   * formatEnum.toString()
-   * @return
-   */
+    * Same as {@link #get(int[], int)}, but accepts a scala.Enumeration for format instead.
+    *
+    * @param columns
+    * @param format
+    * A scala.Enumeration that will be converted to an integer by calling
+    * formatEnum.toString()
+    * @return
+    */
   def get(columns: Array[Int], format: ViewFormat): DDF = {
     format match {
       case ViewFormat.DEFAULT => ViewHandler.getDefault(columns, mDDF)
@@ -56,30 +57,25 @@ class ViewHandler(mDDF: DDF) extends io.ddf.content.ViewHandler(mDDF) with IHand
     this.get(columns, ViewFormat.withName(format))
   }
 
-  override  def getRandomSampleByNum(numSamples: Long, withReplacement: Boolean,
-    seed:
-  Int): DDF = {
+  override def getRandomSampleByNum(numSamples: Long, withReplacement: Boolean,
+                                    seed:
+                                    Int): DDF = {
 
     if (numSamples < 0) {
       throw new IllegalArgumentException("Number of samples must be larger than or equal to 0")
     }
 
-    if (!withReplacement){
+    if (!withReplacement) {
       mDDF.getSqlHandler.sql2ddf(s"select * from ${mDDF.getSchema.getTableName} order by rand($seed) limit $numSamples")
     } else {
 
       val numRows = mDDF.getNumRows
       val rddRow: RDD[Row] = mDDF.asInstanceOf[SparkDDF].getRDD(classOf[Row])
       // We use Spark's API to sample twice what we need, then only pick the first numSamples rows.
-      val sampledRDD = rddRow.sample(true, 2.0 * numSamples/numRows, seed).zipWithIndex().filter(_._2 < numSamples).map(_._1)
+      val sampledRDD = rddRow.sample(true, 2.0 * numSamples / numRows, seed).zipWithIndex().filter(_._2 < numSamples).map(_._1)
 
-      val df: DataFrame = mDDF.getRepresentationHandler.get(classOf[DataFrame]).asInstanceOf[DataFrame]
-      val sqlContext = mDDF.getManager.asInstanceOf[SparkDDFManager].getHiveContext
-      val sampledDF = sqlContext.createDataFrame(sampledRDD, df.schema)
-
-
-      val manager = this.getManager.asInstanceOf[SparkDDFManager]
-      val sampleDDF = manager.newDDFFromSparkDataFrame(sampledDF)
+      val manager = this.getManager
+      val sampleDDF = manager.newDDF(sampledRDD, Array(classOf[RDD[_]], classOf[Row]), manager.getNamespace, null, mDDF.getSchema)
 
       // Copy Factor info
       sampleDDF.getMetaDataHandler.copyFactor(mDDF)
@@ -93,7 +89,7 @@ class ViewHandler(mDDF: DDF) extends io.ddf.content.ViewHandler(mDDF) with IHand
     if (numSamples < 0) {
       throw new IllegalArgumentException("Number of samples must be larger than or equal to 0");
     } else {
-      if(mDDF.getRepresentationHandler.has(classOf[RDD[_]], classOf[Array[Object]])) {
+      if (mDDF.getRepresentationHandler.has(classOf[RDD[_]], classOf[Array[Object]])) {
         val rdd = mDDF.asInstanceOf[SparkDDF].getRDD(classOf[Array[Object]])
         val sampleData = rdd.takeSample(withReplacement, numSamples, seed).toList.asJava
         sampleData
@@ -139,8 +135,8 @@ class ViewHandler(mDDF: DDF) extends io.ddf.content.ViewHandler(mDDF) with IHand
     (classOf[DataFrame]), manager.getNamespace,
       null, schema)
     mLog.info(">>>>>>> adding ddf to DDFManager " + sampleDDF.getName)
-    this.getDDF.getSchemaHandler.getColumns.foreach{
-      col => if(col.getOptionalFactor != null) {
+    this.getDDF.getSchemaHandler.getColumns.foreach {
+      col => if (col.getOptionalFactor != null) {
         sampleDDF.getSchemaHandler.setAsFactor(col.getName)
       }
     }


### PR DESCRIPTION
### Description and related tickets, documents
Also:
- The resulted DDF has exact 'size' number of rows
- Sample by fraction now return exact number of rows as specified by fraction
- The old sample by fraction is renamed to indicate that the result is approximated.

Reviewers: @phvu @hai-adatao @huan
### Breaking changes & backward compatible issues

### How to test
Describe how this PR is tested. In case manual testing is required, describe how to do so.

### PR Progress
Make sure all checkboxes below are checked before merged
- [x] Branch is in format `prefix/description` (see [this](http://www.guyroutledge.co.uk/blog/git-branch-naming-conventions/))
- [ ] Merge check has no conflicts. PR checks passed.
- [ ] Code review is done. 
