### PR TITLE
Add inplace flag to transformrserve methods. 

### DIFF
--- a/core/src/main/java/io/ddf/etl/IHandleTransformations.java
+++ b/core/src/main/java/io/ddf/etl/IHandleTransformations.java
@@ -12,9 +12,15 @@ public interface IHandleTransformations extends IHandleDDFFunctionalGroup {
 
   DDF transformScaleStandard() throws DDFException;
 
+  @Deprecated
   DDF transformNativeRserve(String transformExpression);
 
+  DDF transformNativeRserve(String transformExpression, Boolean inPlace);
+
+  @Deprecated
   DDF transformNativeRserve(String[] transformExpression);
+
+  DDF transformNativeRserve(String[] transformExpression, Boolean inPlace);
 
   DDF transformPython(String[] transformFunctions, String[] functionNames,
       String[] destColumns, String[][] sourceColumns) throws DDFException;

--- a/core/src/main/java/io/ddf/etl/TransformationHandler.java
+++ b/core/src/main/java/io/ddf/etl/TransformationHandler.java
@@ -82,7 +82,15 @@ public class TransformationHandler extends ADDFFunctionalGroupHandler implements
     return null;
   }
 
+  @Override public DDF transformNativeRserve(String transformExpression, Boolean inPlace) {
+    return null;
+  }
+
   @Override public DDF transformNativeRserve(String[] transformExpressions) {
+    return null;
+  }
+
+  @Override public DDF transformNativeRserve(String[] transformExpressions, Boolean inPlace) {
     return null;
   }
 

--- a/core/src/main/java/io/ddf/facades/TransformFacade.java
+++ b/core/src/main/java/io/ddf/facades/TransformFacade.java
@@ -49,13 +49,21 @@ public class TransformFacade implements IHandleTransformations {
   @Override
   public DDF transformNativeRserve(String transformExpression) {
     return mTransformationHandler.transformNativeRserve(transformExpression);
+  }
 
+  @Override
+  public DDF transformNativeRserve(String transformExpression, Boolean inPlace) {
+    return mTransformationHandler.transformNativeRserve(transformExpression, inPlace);
   }
 
   @Override
   public DDF transformNativeRserve(String[] transformExpressions) {
     return mTransformationHandler.transformNativeRserve(transformExpressions);
+  }
 
+  @Override
+  public DDF transformNativeRserve(String[] transformExpressions, Boolean inPlace) {
+    return mTransformationHandler.transformNativeRserve(transformExpressions, inPlace);
   }
 
   @Override

--- a/spark/src/main/scala/io/ddf/spark/etl/TransformationHandler.scala
+++ b/spark/src/main/scala/io/ddf/spark/etl/TransformationHandler.scala
@@ -149,6 +149,15 @@ class TransformationHandler(mDDF: DDF) extends CoreTransformationHandler(mDDF) {
     transformNativeRserve(Array(transformExpression))
   }
 
+  override def transformNativeRserve(transformExpression: String, inPlace: java.lang.Boolean): DDF = {
+    transformNativeRserve(Array(transformExpression), inPlace)
+  }
+
+  override def transformNativeRserve(transformExpression: Array[String], inPlace: java.lang.Boolean): DDF = {
+    val ddf = this.transformNativeRserve(transformExpression)
+    if (inPlace) this.getDDF.updateInplace(ddf) else ddf
+  }
+
   override def transformNativeRserve(transformExpressions: Array[String]): DDF = {
     val dfrdd = mDDF.getRepresentationHandler.get(classOf[RDD[_]], classOf[REXP]).asInstanceOf[RDD[REXP]]
 

--- a/spark/src/main/scala/io/ddf/spark/etl/TransformationHandler.scala
+++ b/spark/src/main/scala/io/ddf/spark/etl/TransformationHandler.scala
@@ -153,12 +153,7 @@ class TransformationHandler(mDDF: DDF) extends CoreTransformationHandler(mDDF) {
     transformNativeRserve(Array(transformExpression), inPlace)
   }
 
-  override def transformNativeRserve(transformExpression: Array[String], inPlace: java.lang.Boolean): DDF = {
-    val ddf = this.transformNativeRserve(transformExpression)
-    if (inPlace) this.getDDF.updateInplace(ddf) else ddf
-  }
-
-  override def transformNativeRserve(transformExpressions: Array[String]): DDF = {
+  override def transformNativeRserve(transformExpressions: Array[String], inPlace: java.lang.Boolean): DDF = {
     val dfrdd = mDDF.getRepresentationHandler.get(classOf[RDD[_]], classOf[REXP]).asInstanceOf[RDD[REXP]]
 
     // process each DF partition in R
@@ -214,7 +209,12 @@ class TransformationHandler(mDDF: DDF) extends CoreTransformationHandler(mDDF) {
       newSchema)
     mLog.info(">>>>> adding ddf to manager: " + ddf.getName)
     ddf.getMetaDataHandler.copyFactor(this.getDDF)
-    ddf
+
+    if (inPlace) this.getDDF.updateInplace(ddf) else ddf
+  }
+
+  override def transformNativeRserve(transformExpressions: Array[String]): DDF = {
+    transformNativeRserve(transformExpressions, false)
   }
 
 

--- a/spark/src/test/java/io/ddf/spark/etl/TransformationHandlerTest.java
+++ b/spark/src/test/java/io/ddf/spark/etl/TransformationHandlerTest.java
@@ -43,27 +43,48 @@ public class TransformationHandlerTest extends BaseTest {
 
   @Test
   public void testTransformNativeRserveInPlaceSingleExpression() throws DDFException {
+    Boolean inPlace = Boolean.TRUE;
+    // Inplace TRUE
     DDF newDdf = ddf.copy();
-    DDF newDdf2 = newDdf.Transform.transformNativeRserve("newcol = deptime / arrtime", Boolean.TRUE);
+    DDF newDdf2 = newDdf.Transform.transformNativeRserve("newcol = deptime / arrtime", inPlace);
     List<String> res = newDdf2.VIEWS.head(10);
     Assert.assertNotNull(newDdf2);
     Assert.assertNotNull(newDdf);
-    Assert.assertTrue(newDdf.getUUID().equals(newDdf2.getUUID()));
+    Assert.assertTrue("With inPlace being true, two DDF should have the same UUID", newDdf.getUUID().equals(newDdf2.getUUID()));
     Assert.assertEquals("newcol", newDdf.getColumnName(8));
     Assert.assertEquals(10, res.size());
+
+    //Inplace FALSE
+    inPlace = Boolean.FALSE;
+    DDF newDdf3 = ddf.copy();
+    DDF newDdf4 = newDdf.Transform.transformNativeRserve("newcol = deptime / arrtime", inPlace);
+    Assert.assertNotNull(newDdf3);
+    Assert.assertNotNull(newDdf4);
+    Assert.assertFalse("With inPlace being false, two DDF should have different UUID", newDdf3.getUUID().equals(newDdf4.getUUID()));
   }
 
   @Test
   public void testTransformNativeRserveInPlaceMultipleExpression() throws DDFException {
+    Boolean inPlace = Boolean.TRUE;
+
+    // Inplace TRUE
     String[] expressions = {"newcol = deptime / arrtime","newcol2=log(arrdelay)"};
     DDF newDdf = ddf.copy();
-    DDF newDdf2 = newDdf.Transform.transformNativeRserve(expressions, Boolean.TRUE);
+    DDF newDdf2 = newDdf.Transform.transformNativeRserve(expressions, inPlace);
     List<String> res = newDdf2.VIEWS.head(10);
     Assert.assertNotNull(newDdf2);
     Assert.assertNotNull(newDdf);
-    Assert.assertTrue(newDdf.getUUID().equals(newDdf2.getUUID()));
+    Assert.assertTrue("With inPlace being true, two DDF should have the same UUID", newDdf.getUUID().equals(newDdf2.getUUID()));
     Assert.assertEquals("newcol", newDdf2.getColumnName(8));
     Assert.assertEquals("newcol2", newDdf2.getColumnName(9));
+
+    // Inplace FALSE
+    inPlace = Boolean.FALSE;
+    DDF newDdf3 = ddf.copy();
+    DDF newDdf4 = newDdf.Transform.transformNativeRserve(expressions, inPlace);
+    Assert.assertNotNull(newDdf3);
+    Assert.assertNotNull(newDdf4);
+    Assert.assertFalse("With inPlace being false, two DDF should have different UUID", newDdf3.getUUID().equals(newDdf4.getUUID()));
   }
 
   @Test

--- a/spark/src/test/java/io/ddf/spark/etl/TransformationHandlerTest.java
+++ b/spark/src/test/java/io/ddf/spark/etl/TransformationHandlerTest.java
@@ -10,7 +10,6 @@ import io.ddf.etl.TransformationHandler;
 import io.ddf.exception.DDFException;
 import io.ddf.spark.BaseTest;
 import org.junit.*;
-import org.junit.rules.ExpectedException;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -42,46 +41,51 @@ public class TransformationHandlerTest extends BaseTest {
   }
 
   @Test
-  public void testTransformNativeRserveInPlaceSingleExpression() throws DDFException {
+  public void testTransformNativeRserveSingleExpressionInPlaceTrue() throws DDFException {
     Boolean inPlace = Boolean.TRUE;
-    // Inplace TRUE
     DDF newDdf = ddf.copy();
     DDF newDdf2 = newDdf.Transform.transformNativeRserve("newcol = deptime / arrtime", inPlace);
     List<String> res = newDdf2.VIEWS.head(10);
+
     Assert.assertNotNull(newDdf2);
     Assert.assertNotNull(newDdf);
     Assert.assertTrue("With inPlace being true, two DDF should have the same UUID", newDdf.getUUID().equals(newDdf2.getUUID()));
     Assert.assertEquals("newcol", newDdf.getColumnName(8));
     Assert.assertEquals(10, res.size());
+  }
 
-    //Inplace FALSE
-    inPlace = Boolean.FALSE;
+  @Test
+  public void testTransformNativeRserveSingleExpressionInPlaceFalse() throws DDFException {
+    Boolean inPlace = Boolean.FALSE;
     DDF newDdf3 = ddf.copy();
-    DDF newDdf4 = newDdf.Transform.transformNativeRserve("newcol = deptime / arrtime", inPlace);
+    DDF newDdf4 = newDdf3.Transform.transformNativeRserve("newcol = deptime / arrtime", inPlace);
+
     Assert.assertNotNull(newDdf3);
     Assert.assertNotNull(newDdf4);
     Assert.assertFalse("With inPlace being false, two DDF should have different UUID", newDdf3.getUUID().equals(newDdf4.getUUID()));
   }
 
   @Test
-  public void testTransformNativeRserveInPlaceMultipleExpression() throws DDFException {
+  public void testTransformNativeRserveMultipleExpressionInPlaceTrue() throws DDFException {
     Boolean inPlace = Boolean.TRUE;
-
-    // Inplace TRUE
     String[] expressions = {"newcol = deptime / arrtime","newcol2=log(arrdelay)"};
     DDF newDdf = ddf.copy();
     DDF newDdf2 = newDdf.Transform.transformNativeRserve(expressions, inPlace);
-    List<String> res = newDdf2.VIEWS.head(10);
+    
     Assert.assertNotNull(newDdf2);
     Assert.assertNotNull(newDdf);
     Assert.assertTrue("With inPlace being true, two DDF should have the same UUID", newDdf.getUUID().equals(newDdf2.getUUID()));
     Assert.assertEquals("newcol", newDdf2.getColumnName(8));
     Assert.assertEquals("newcol2", newDdf2.getColumnName(9));
+  }
 
-    // Inplace FALSE
-    inPlace = Boolean.FALSE;
+  @Test
+  public void testTransformNativeRserveMultipleExpressionInPlaceFalse() throws DDFException {
+    Boolean inPlace = Boolean.FALSE;
+    String[] expressions = {"newcol = deptime / arrtime","newcol2=log(arrdelay)"};
     DDF newDdf3 = ddf.copy();
-    DDF newDdf4 = newDdf.Transform.transformNativeRserve(expressions, inPlace);
+    DDF newDdf4 = newDdf3.Transform.transformNativeRserve(expressions, inPlace);
+
     Assert.assertNotNull(newDdf3);
     Assert.assertNotNull(newDdf4);
     Assert.assertFalse("With inPlace being false, two DDF should have different UUID", newDdf3.getUUID().equals(newDdf4.getUUID()));

--- a/spark/src/test/java/io/ddf/spark/etl/TransformationHandlerTest.java
+++ b/spark/src/test/java/io/ddf/spark/etl/TransformationHandlerTest.java
@@ -47,10 +47,11 @@ public class TransformationHandlerTest extends BaseTest {
     DDF newDdf2 = newDdf.Transform.transformNativeRserve("newcol = deptime / arrtime", inPlace);
     List<String> res = newDdf2.VIEWS.head(10);
 
-    Assert.assertNotNull(newDdf2);
     Assert.assertNotNull(newDdf);
+    Assert.assertNotNull(newDdf2);
     Assert.assertTrue("With inPlace being true, two DDF should have the same UUID", newDdf.getUUID().equals(newDdf2.getUUID()));
-    Assert.assertEquals("newcol", newDdf.getColumnName(8));
+    Assert.assertEquals("With inPlace being true, original DDF should have newcol added", "newcol", newDdf.getColumnName(8));
+    Assert.assertEquals("transformed DDF newDdf2 should have newcol added", "newcol", newDdf2.getColumnName(8));
     Assert.assertEquals(10, res.size());
   }
 
@@ -62,6 +63,7 @@ public class TransformationHandlerTest extends BaseTest {
 
     Assert.assertNotNull(newDdf3);
     Assert.assertNotNull(newDdf4);
+    Assert.assertEquals("transformed DDF newDdf4 should have newcol added", "newcol", newDdf4.getColumnName(8));
     Assert.assertFalse("With inPlace being false, two DDF should have different UUID", newDdf3.getUUID().equals(newDdf4.getUUID()));
   }
 
@@ -71,12 +73,14 @@ public class TransformationHandlerTest extends BaseTest {
     String[] expressions = {"newcol = deptime / arrtime","newcol2=log(arrdelay)"};
     DDF newDdf = ddf.copy();
     DDF newDdf2 = newDdf.Transform.transformNativeRserve(expressions, inPlace);
-    
-    Assert.assertNotNull(newDdf2);
+
     Assert.assertNotNull(newDdf);
+    Assert.assertNotNull(newDdf2);
     Assert.assertTrue("With inPlace being true, two DDF should have the same UUID", newDdf.getUUID().equals(newDdf2.getUUID()));
-    Assert.assertEquals("newcol", newDdf2.getColumnName(8));
-    Assert.assertEquals("newcol2", newDdf2.getColumnName(9));
+    Assert.assertEquals("With inPlace being true, original DDF should have newcol added", "newcol", newDdf.getColumnName(8));
+    Assert.assertEquals("With inPlace being true, original DDF should have newcol2 added", "newcol2", newDdf.getColumnName(9));
+    Assert.assertEquals("transformed DDF newDdf2 should have newcol added", "newcol", newDdf2.getColumnName(8));
+    Assert.assertEquals("transformed DDF newDdf2 should have newcol2 added", "newcol2", newDdf2.getColumnName(9));
   }
 
   @Test
@@ -89,6 +93,8 @@ public class TransformationHandlerTest extends BaseTest {
     Assert.assertNotNull(newDdf3);
     Assert.assertNotNull(newDdf4);
     Assert.assertFalse("With inPlace being false, two DDF should have different UUID", newDdf3.getUUID().equals(newDdf4.getUUID()));
+    Assert.assertEquals("transformed DDF newDdf4 should have newcol added", "newcol", newDdf4.getColumnName(8));
+    Assert.assertEquals("transformed DDF newDdf4 should have newcol2 added", "newcol2", newDdf4.getColumnName(9));
   }
 
   @Test

--- a/spark/src/test/java/io/ddf/spark/etl/TransformationHandlerTest.java
+++ b/spark/src/test/java/io/ddf/spark/etl/TransformationHandlerTest.java
@@ -42,6 +42,31 @@ public class TransformationHandlerTest extends BaseTest {
   }
 
   @Test
+  public void testTransformNativeRserveInPlaceSingleExpression() throws DDFException {
+    DDF newDdf = ddf.copy();
+    DDF newDdf2 = newDdf.Transform.transformNativeRserve("newcol = deptime / arrtime", Boolean.TRUE);
+    List<String> res = newDdf2.VIEWS.head(10);
+    Assert.assertNotNull(newDdf2);
+    Assert.assertNotNull(newDdf);
+    Assert.assertTrue(newDdf.getUUID().equals(newDdf2.getUUID()));
+    Assert.assertEquals("newcol", newDdf.getColumnName(8));
+    Assert.assertEquals(10, res.size());
+  }
+
+  @Test
+  public void testTransformNativeRserveInPlaceMultipleExpression() throws DDFException {
+    String[] expressions = {"newcol = deptime / arrtime","newcol2=log(arrdelay)"};
+    DDF newDdf = ddf.copy();
+    DDF newDdf2 = newDdf.Transform.transformNativeRserve(expressions, Boolean.TRUE);
+    List<String> res = newDdf2.VIEWS.head(10);
+    Assert.assertNotNull(newDdf2);
+    Assert.assertNotNull(newDdf);
+    Assert.assertTrue(newDdf.getUUID().equals(newDdf2.getUUID()));
+    Assert.assertEquals("newcol", newDdf2.getColumnName(8));
+    Assert.assertEquals("newcol2", newDdf2.getColumnName(9));
+  }
+
+  @Test
   public void testTransformPython() throws DDFException {
     // f = lambda x: x/2.
     // f = lambda x: x+10
@@ -486,7 +511,6 @@ public class TransformationHandlerTest extends BaseTest {
     DDF newDDF = ddf.Transform.castType("year", "string");
     assert(newDDF.getUUID() != ddf.getUUID());
     assert(newDDF.getColumn("year").getType() == ColumnType.STRING);
-    assert(ddf.getColumn("year").getType() == ColumnType.STRING);
   }
 
   @Test
@@ -494,5 +518,6 @@ public class TransformationHandlerTest extends BaseTest {
     DDF newDDF = ddf.Transform.castType("year", "string", true);
     assert(newDDF.getUUID() == ddf.getUUID());
     assert(newDDF.getColumn("year").getType() == ColumnType.STRING);
+    assert(ddf.getColumn("year").getType() == ColumnType.STRING);
   }
 }


### PR DESCRIPTION
### Description and related tickets, documents
Add inplace flag to transformrserve methods, with true to transform the DDF inplace (i.e: existing DDF is modified)

Reviewers: @hai-adatao @nhanitvn @Huandao0812 @phvu 

### Breaking changes & backward compatible issues
Is this PR a breaking change or has backward compatible issue (e.g: changes in API names, interfaces, signature / remove something...)?
If yes, please state out what and tag, and if it can possibly affect BA, please tag aht, tuananh, khangpham and baonguyen

### How to test
Describe how this PR is tested. In case manual testing is required, describe how to do so.

### PR Progress
Make sure all checkboxes below are checked before merged
- [x] Branch is in format `prefix/description` (see [this](http://www.guyroutledge.co.uk/blog/git-branch-naming-conventions/))
- [x] Merge check has no conflicts. PR checks passed.
- [x] Code review is done. 