### PR TITLE
Update the way we do sampling without replacement

### DIFF
--- a/spark/src/main/scala/io/ddf/spark/content/ViewHandler.scala
+++ b/spark/src/main/scala/io/ddf/spark/content/ViewHandler.scala
@@ -68,9 +68,13 @@ class ViewHandler(mDDF: DDF) extends io.ddf.content.ViewHandler(mDDF) with IHand
     }
 
     if (!withReplacement) {
-      // This subquery is a workaround for Spark's inability to order rows by rand(<negative_seed>)
-      // Example: select * from table order by rand(-123)
-      mDDF.getSqlHandler.sql2ddf(s"select ${mDDF.getColumnNames.mkString(",")} from (select *, rand($seed) as rnd from ${mDDF.getSchema.getTableName}) t order by rnd limit $numSamples")
+      if (seed >= 0) {
+        mDDF.getSqlHandler.sql2ddf(s"select * from ${mDDF.getSchema.getTableName} order by rand($seed) limit $numSamples")
+      } else {
+        // This is a workaround to deal with Spark's inability to order rows by rand(<negative_seed>)
+        // Example: select * from table order by rand(-123)
+        mDDF.getSqlHandler.sql2ddf(s"select ${mDDF.getColumnNames.mkString(",")} from (select *, rand($seed) as rnd from ${mDDF.getSchema.getTableName}) t order by rnd limit $numSamples")
+      }
     } else {
 
       val numRows = mDDF.getNumRows
@@ -88,7 +92,6 @@ class ViewHandler(mDDF: DDF) extends io.ddf.content.ViewHandler(mDDF) with IHand
 
       sampleDDF
     }
-
   }
 
   override def getRandomSample(numSamples: Int, withReplacement: Boolean, seed: Int): java.util.List[Array[Object]] = {

--- a/spark/src/main/scala/io/ddf/spark/content/ViewHandler.scala
+++ b/spark/src/main/scala/io/ddf/spark/content/ViewHandler.scala
@@ -68,7 +68,9 @@ class ViewHandler(mDDF: DDF) extends io.ddf.content.ViewHandler(mDDF) with IHand
     }
 
     if (!withReplacement) {
-      mDDF.getSqlHandler.sql2ddf(s"select * from ${mDDF.getSchema.getTableName} order by rand($seed) limit $numSamples")
+      // This subquery is a workaround for Spark's inability to order rows by rand(<negative_seed>)
+      // Example: select * from table order by rand(-123)
+      mDDF.getSqlHandler.sql2ddf(s"select ${mDDF.getColumnNames.mkString(",")} from (select *, rand($seed) as rnd from ${mDDF.getSchema.getTableName}) t order by rnd limit $numSamples")
     } else {
 
       val numRows = mDDF.getNumRows

--- a/spark/src/test/java/io/ddf/spark/content/ViewHandlerTest.java
+++ b/spark/src/test/java/io/ddf/spark/content/ViewHandlerTest.java
@@ -8,7 +8,7 @@ import io.ddf.content.ViewHandler;
 import io.ddf.content.ViewHandler.*;
 import io.ddf.exception.DDFException;
 import io.ddf.spark.BaseTest;
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.List;
@@ -126,11 +126,23 @@ public class ViewHandlerTest extends BaseTest{
     for(long sampleSize: sampleSizes) {
       // sample with replacement
       DDF randomSample = ddf.VIEWS.getRandomSampleByNum(sampleSize, true, 123);
-      Assert.assertTrue(randomSample.getNumRows() == sampleSize);
+      Assert.assertArrayEquals(randomSample.getColumnNames().toArray(), ddf.getColumnNames().toArray());
+      Assert.assertEquals(randomSample.getNumRows(), sampleSize);
+
+      // sample with replacement and negative seed
+      randomSample = ddf.VIEWS.getRandomSampleByNum(sampleSize, true, -123);
+      Assert.assertArrayEquals(randomSample.getColumnNames().toArray(), ddf.getColumnNames().toArray());
+      Assert.assertEquals(randomSample.getNumRows(), sampleSize);
 
       // sample without replacement
       randomSample = ddf.VIEWS.getRandomSampleByNum(sampleSize, false, 123);
-      Assert.assertTrue(randomSample.getNumRows() == sampleSize);
+      Assert.assertArrayEquals(randomSample.getColumnNames().toArray(), ddf.getColumnNames().toArray());
+      Assert.assertEquals(randomSample.getNumRows(), sampleSize);
+
+      // sample without replacement with negative seed
+      randomSample = ddf.VIEWS.getRandomSampleByNum(sampleSize, false, -123);
+      Assert.assertArrayEquals(randomSample.getColumnNames().toArray(), ddf.getColumnNames().toArray());
+      Assert.assertEquals(randomSample.getNumRows(), sampleSize);
     }
 
     try {
@@ -153,10 +165,22 @@ public class ViewHandlerTest extends BaseTest{
     for(double fraction: fractions) {
       // sample with replacement
       DDF ddf2 = ddf.VIEWS.getRandomSample(fraction, true, 123);
+      Assert.assertArrayEquals(ddf2.getColumnNames().toArray(), ddf.getColumnNames().toArray());
+      Assert.assertTrue(ddf2.getNumRows() == Math.round(numRows * fraction));
+
+      // sample with replacement with negative seed
+      ddf2 = ddf.VIEWS.getRandomSample(fraction, true, -123);
+      Assert.assertArrayEquals(ddf2.getColumnNames().toArray(), ddf.getColumnNames().toArray());
       Assert.assertTrue(ddf2.getNumRows() == Math.round(numRows * fraction));
 
       // sample without replacement
       ddf2 = ddf.VIEWS.getRandomSample(fraction, false, 123);
+      Assert.assertArrayEquals(ddf2.getColumnNames().toArray(), ddf.getColumnNames().toArray());
+      Assert.assertTrue(ddf2.getNumRows() == Math.round(numRows * fraction));
+
+      // sample without replacement with negative seed
+      ddf2 = ddf.VIEWS.getRandomSample(fraction, true, -123);
+      Assert.assertArrayEquals(ddf2.getColumnNames().toArray(), ddf.getColumnNames().toArray());
       Assert.assertTrue(ddf2.getNumRows() == Math.round(numRows * fraction));
     }
 


### PR DESCRIPTION
### Description and related tickets, documents
 due to the fact that SparkSQL does not allow rand() to accept a negative seed value in order by clause

Reviewers: @hai-adatao 

### Breaking changes & backward compatible issues

### How to test
Describe how this PR is tested. In case manual testing is required, describe how to do so.

### PR Progress
Make sure all checkboxes below are checked before merged
- [x] Branch is in format `prefix/description` (see [this](http://www.guyroutledge.co.uk/blog/git-branch-naming-conventions/))
- [x] Merge check has no conflicts. PR checks passed.
- [x] Code review is done. 

Change-Id: I34ebed02c4ff615aae99a30cd68c3e1104ee3dc0