### PR TITLE
Add support to scale just a subset of columns plus and inPlace flag

### DIFF
--- a/core/src/main/java/io/ddf/etl/IHandleTransformations.java
+++ b/core/src/main/java/io/ddf/etl/IHandleTransformations.java
@@ -8,9 +8,15 @@ import java.util.List;
 
 public interface IHandleTransformations extends IHandleDDFFunctionalGroup {
 
+  @Deprecated
   DDF transformScaleMinMax() throws DDFException;
 
+  DDF transformScaleMinMax(List<String> columns, Boolean inPlace) throws DDFException;
+
+  @Deprecated
   DDF transformScaleStandard() throws DDFException;
+
+  DDF transformScaleStandard(List<String> columns, Boolean inPlace) throws DDFException;
 
   @Deprecated
   DDF transformNativeRserve(String transformExpression);

--- a/core/src/main/java/io/ddf/etl/TransformationHandler.java
+++ b/core/src/main/java/io/ddf/etl/TransformationHandler.java
@@ -30,7 +30,7 @@ public class TransformationHandler extends ADDFFunctionalGroupHandler implements
 
   @Override
   public DDF transformScaleMinMax() throws DDFException {
-    return this.transformScaleMinMax(new ArrayList<>(), Boolean.FALSE);
+    return this.transformScaleMinMax(null, Boolean.FALSE);
   }
 
   @Override
@@ -74,7 +74,7 @@ public class TransformationHandler extends ADDFFunctionalGroupHandler implements
 
   @Override
   public DDF transformScaleStandard() throws DDFException {
-    return this.transformScaleStandard(new ArrayList<>(), Boolean.FALSE);
+    return this.transformScaleStandard(null, Boolean.FALSE);
   }
 
   @Override
@@ -502,6 +502,6 @@ public class TransformationHandler extends ADDFFunctionalGroupHandler implements
   private boolean isColumnEligibleToScale(Column column, List<String> scaleRequestedColumnNames) {
     return (column.isNumeric()
             && column.getColumnClass() != ColumnClass.FACTOR
-            && ((scaleRequestedColumnNames == null) || scaleRequestedColumnNames.isEmpty() || scaleRequestedColumnNames.contains(column.getName())));
+            && ((scaleRequestedColumnNames == null) || scaleRequestedColumnNames.contains(column.getName())));
   }
 }

--- a/core/src/main/java/io/ddf/etl/TransformationHandler.java
+++ b/core/src/main/java/io/ddf/etl/TransformationHandler.java
@@ -13,6 +13,7 @@ import io.ddf.datasource.SQLDataSourceDescriptor;
 import io.ddf.exception.DDFException;
 import io.ddf.misc.ADDFFunctionalGroupHandler;
 import io.ddf.util.Utils;
+import org.apache.commons.lang.StringEscapeUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,29 +43,30 @@ public class TransformationHandler extends ADDFFunctionalGroupHandler implements
 
     for (int colIndex = 0; colIndex < schema.getNumColumns(); colIndex++) {
       Column col = schema.getColumn(colIndex);
+      String escapedColName = StringEscapeUtils.escapeJava(col.getName());
 
       if (!isColumnEligibleToScale(col, columns)) {
-        sqlCmdBuffer.append(col.getName()).append(",");
+        sqlCmdBuffer.append(escapedColName).append(",");
       } else {
         if (summaryArr[colIndex] == null) {
           LOG.warn("Missing column summary. transformScaleMinMax ignored for column: " + col.getName());
 
-          sqlCmdBuffer.append(col.getName()).append(" ");
+          sqlCmdBuffer.append(escapedColName).append(" ");
         } else if (Double.compare(summaryArr[colIndex].max(), summaryArr[colIndex].min()) == 0) {
           LOG.warn("max equals min. transformScaleMinMax ignored for column: " + col.getName());
 
-          sqlCmdBuffer.append(col.getName()).append(" ");
+          sqlCmdBuffer.append(escapedColName).append(" ");
         } else {
           // subtract min, divide by (max - min)
-          sqlCmdBuffer.append(String.format("((%s - %s) / %s) as %s ", col.getName(), summaryArr[colIndex].min(),
-                  (summaryArr[colIndex].max() - summaryArr[colIndex].min()), col.getName()));
+          sqlCmdBuffer.append(String.format("((%s - %s) / %s) as %s ", escapedColName, summaryArr[colIndex].min(),
+                  (summaryArr[colIndex].max() - summaryArr[colIndex].min()), escapedColName));
         }
 
         sqlCmdBuffer.append(",");
       }
     }
     sqlCmdBuffer.setLength(sqlCmdBuffer.length() - 1);
-    sqlCmdBuffer.append(" FROM ").append(schema.getTableName());
+    sqlCmdBuffer.append(" FROM ").append(StringEscapeUtils.escapeJava(schema.getTableName()));
 
     DDF newddf = this.getManager().sql2ddf(sqlCmdBuffer.toString(), this.getEngine());
     newddf.getMetaDataHandler().copyFactor(this.getDDF());
@@ -86,30 +88,31 @@ public class TransformationHandler extends ADDFFunctionalGroupHandler implements
 
     for (int colIndex = 0; colIndex < schema.getNumColumns(); colIndex++) {
       Column col = schema.getColumn(colIndex);
+      String escapedColName = StringEscapeUtils.escapeJava(col.getName());
 
       if (!isColumnEligibleToScale(col, columns)) {
-        sqlCmdBuffer.append(col.getName()).append(",");
+        sqlCmdBuffer.append(escapedColName).append(",");
       } else {
         if (summaryArr[colIndex] == null) {
           LOG.warn("Missing column summary. transformScaleStandard ignored for column: " + col.getName());
 
-          sqlCmdBuffer.append(col.getName()).append(" ");
+          sqlCmdBuffer.append(escapedColName).append(" ");
         } else if (summaryArr[colIndex].stdev() == 0) {
           LOG.warn("standard deviation equals zero. transformScaleStandard ignored for column: " + col.getName());
 
-          sqlCmdBuffer.append(col.getName()).append(" ");
+          sqlCmdBuffer.append(escapedColName).append(" ");
         } else {
           // subtract mean, divide by stdev
           sqlCmdBuffer.append(String
-                  .format("((%s - %s) / %s) as %s ", col.getName(), summaryArr[colIndex].mean(), summaryArr[colIndex].stdev(),
-                          col.getName()));
+                  .format("((%s - %s) / %s) as %s ", escapedColName, summaryArr[colIndex].mean(), summaryArr[colIndex].stdev(),
+                          escapedColName));
         }
 
         sqlCmdBuffer.append(",");
       }
     }
     sqlCmdBuffer.setLength(sqlCmdBuffer.length() - 1);
-    sqlCmdBuffer.append(" FROM ").append(schema.getTableName());
+    sqlCmdBuffer.append(" FROM ").append(StringEscapeUtils.escapeJava(schema.getTableName()));
 
     DDF newddf = this.getManager().sql2ddf(sqlCmdBuffer.toString(), this.getEngine());
     newddf.getMetaDataHandler().copyFactor(this.getDDF());

--- a/core/src/main/java/io/ddf/etl/TransformationHandler.java
+++ b/core/src/main/java/io/ddf/etl/TransformationHandler.java
@@ -5,6 +5,7 @@ package io.ddf.etl;
 import com.google.common.collect.Lists;
 import io.ddf.DDF;
 import io.ddf.analytics.Summary;
+import io.ddf.content.Schema;
 import io.ddf.content.Schema.Column;
 import io.ddf.content.Schema.ColumnClass;
 import io.ddf.content.Schema.ColumnType;
@@ -35,11 +36,12 @@ public class TransformationHandler extends ADDFFunctionalGroupHandler implements
   @Override
   public DDF transformScaleMinMax(List<String> columns, Boolean inPlace) throws DDFException {
     Summary[] summaryArr = this.getDDF().getSummary();
+    Schema schema = this.getDDF().getSchema();
     // Compose a transformation query
     StringBuilder sqlCmdBuffer = new StringBuilder("SELECT ");
 
-    for (int colIndex = 0; colIndex < this.getDDF().getSchema().getNumColumns(); colIndex++) {
-      Column col = this.getDDF().getSchema().getColumn(colIndex);
+    for (int colIndex = 0; colIndex < schema.getNumColumns(); colIndex++) {
+      Column col = schema.getColumn(colIndex);
 
       if (!isColumnEligibleToScale(col, columns)) {
         sqlCmdBuffer.append(col.getName()).append(",");
@@ -62,7 +64,7 @@ public class TransformationHandler extends ADDFFunctionalGroupHandler implements
       }
     }
     sqlCmdBuffer.setLength(sqlCmdBuffer.length() - 1);
-    sqlCmdBuffer.append(" FROM ").append(this.getDDF().getTableName());
+    sqlCmdBuffer.append(" FROM ").append(schema.getTableName());
 
     DDF newddf = this.getManager().sql2ddf(sqlCmdBuffer.toString(), this.getEngine());
     newddf.getMetaDataHandler().copyFactor(this.getDDF());
@@ -78,11 +80,12 @@ public class TransformationHandler extends ADDFFunctionalGroupHandler implements
   @Override
   public DDF transformScaleStandard(List<String> columns, Boolean inPlace) throws DDFException {
     Summary[] summaryArr = this.getDDF().getSummary();
+    Schema schema = this.getDDF().getSchema();
     // Compose a transformation query
     StringBuilder sqlCmdBuffer = new StringBuilder("SELECT ");
 
-    for (int colIndex = 0; colIndex < this.getDDF().getSchema().getNumColumns(); colIndex++) {
-      Column col = this.getDDF().getSchema().getColumn(colIndex);
+    for (int colIndex = 0; colIndex < schema.getNumColumns(); colIndex++) {
+      Column col = schema.getColumn(colIndex);
 
       if (!isColumnEligibleToScale(col, columns)) {
         sqlCmdBuffer.append(col.getName()).append(",");
@@ -106,7 +109,7 @@ public class TransformationHandler extends ADDFFunctionalGroupHandler implements
       }
     }
     sqlCmdBuffer.setLength(sqlCmdBuffer.length() - 1);
-    sqlCmdBuffer.append(" FROM ").append(this.getDDF().getTableName());
+    sqlCmdBuffer.append(" FROM ").append(schema.getTableName());
 
     DDF newddf = this.getManager().sql2ddf(sqlCmdBuffer.toString(), this.getEngine());
     newddf.getMetaDataHandler().copyFactor(this.getDDF());

--- a/core/src/main/java/io/ddf/etl/TransformationHandler.java
+++ b/core/src/main/java/io/ddf/etl/TransformationHandler.java
@@ -12,70 +12,108 @@ import io.ddf.datasource.SQLDataSourceDescriptor;
 import io.ddf.exception.DDFException;
 import io.ddf.misc.ADDFFunctionalGroupHandler;
 import io.ddf.util.Utils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.*;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 public class TransformationHandler extends ADDFFunctionalGroupHandler implements IHandleTransformations {
+
+  private static Logger LOG = LoggerFactory.getLogger(TransformationHandler.class);
 
   public TransformationHandler(DDF theDDF) {
     super(theDDF);
     // TODO Auto-generated constructor stub
   }
 
-  @Override public DDF transformScaleMinMax() throws DDFException {
-    Summary[] summaryArr = this.getDDF().getSummary();
-    List<Column> columns = this.getDDF().getSchema().getColumns();
-
-    // Compose a transformation query
-    StringBuffer sqlCmdBuffer = new StringBuffer("SELECT ");
-
-    for (int i = 0; i < columns.size(); i++) {
-      Column col = columns.get(i);
-      if (!col.isNumeric() || col.getColumnClass() == ColumnClass.FACTOR) {
-        sqlCmdBuffer.append(col.getName()).append(" ");
-      } else {
-        // subtract min, divide by (max - min)
-        sqlCmdBuffer.append(String.format("((%s - %s) / %s) as %s ", col.getName(), summaryArr[i].min(),
-            (summaryArr[i].max() - summaryArr[i].min()), col.getName()));
-      }
-      sqlCmdBuffer.append(",");
-    }
-    sqlCmdBuffer.setLength(sqlCmdBuffer.length() - 1);
-    sqlCmdBuffer.append("FROM ").append(this.getDDF().getTableName());
-
-    DDF newddf = this.getManager().sql2ddf(sqlCmdBuffer.toString(), this.getEngine());
-    newddf.getMetaDataHandler().copyFactor(this.getDDF());
-    return newddf;
+  @Override
+  public DDF transformScaleMinMax() throws DDFException {
+    return this.transformScaleMinMax(new ArrayList<>(), Boolean.FALSE);
   }
 
-  @Override public DDF transformScaleStandard() throws DDFException {
+  @Override
+  public DDF transformScaleMinMax(List<String> columns, Boolean inPlace) throws DDFException {
     Summary[] summaryArr = this.getDDF().getSummary();
-    List<Column> columns = this.getDDF().getSchema().getColumns();
-
     // Compose a transformation query
-    StringBuffer sqlCmdBuffer = new StringBuffer("SELECT ");
+    StringBuilder sqlCmdBuffer = new StringBuilder("SELECT ");
 
-    for (int i = 0; i < columns.size(); i++) {
-      Column col = columns.get(i);
-      if (!col.isNumeric() || col.getColumnClass() == ColumnClass.FACTOR) {
-        sqlCmdBuffer.append(col.getName()).append(" ");
+    for (int colIndex = 0; colIndex < this.getDDF().getSchema().getNumColumns(); colIndex++) {
+      Column col = this.getDDF().getSchema().getColumn(colIndex);
+
+      if (!col.isNumeric() || col.getColumnClass() == ColumnClass.FACTOR
+              || ((columns != null) && (!columns.isEmpty()) && (!columns.contains(col.getName()))) ) {
+        sqlCmdBuffer.append(col.getName()).append(",");
       } else {
-        // subtract mean, divide by stdev
-        sqlCmdBuffer.append(String
-            .format("((%s - %s) / %s) as %s ", col.getName(), summaryArr[i].mean(), summaryArr[i].stdev(),
-                col.getName()));
+        if (summaryArr[colIndex] == null) {
+          LOG.warn("Missing column summary. transformScaleMinMax ignored for column: " + col.getName());
+
+          sqlCmdBuffer.append(col.getName()).append(" ");
+        } else if (Double.compare(summaryArr[colIndex].max(), summaryArr[colIndex].min()) == 0) {
+          LOG.warn("max equals min. transformScaleMinMax ignored for column: " + col.getName());
+
+          sqlCmdBuffer.append(col.getName()).append(" ");
+        } else {
+          // subtract min, divide by (max - min)
+          sqlCmdBuffer.append(String.format("((%s - %s) / %s) as %s ", col.getName(), summaryArr[colIndex].min(),
+                  (summaryArr[colIndex].max() - summaryArr[colIndex].min()), col.getName()));
+        }
+
+        sqlCmdBuffer.append(",");
       }
-      sqlCmdBuffer.append(",");
     }
     sqlCmdBuffer.setLength(sqlCmdBuffer.length() - 1);
-    sqlCmdBuffer.append("FROM ").append(this.getDDF().getTableName());
+    sqlCmdBuffer.append(" FROM ").append(this.getDDF().getTableName());
 
     DDF newddf = this.getManager().sql2ddf(sqlCmdBuffer.toString(), this.getEngine());
     newddf.getMetaDataHandler().copyFactor(this.getDDF());
-    return newddf;
 
+    return inPlace ? this.getDDF().updateInplace(newddf) : newddf;
+  }
+
+  @Override
+  public DDF transformScaleStandard() throws DDFException {
+    return this.transformScaleStandard(new ArrayList<>(), Boolean.FALSE);
+  }
+
+  @Override
+  public DDF transformScaleStandard(List<String> columns, Boolean inPlace) throws DDFException {
+    Summary[] summaryArr = this.getDDF().getSummary();
+    // Compose a transformation query
+    StringBuilder sqlCmdBuffer = new StringBuilder("SELECT ");
+
+    for (int colIndex = 0; colIndex < this.getDDF().getSchema().getNumColumns(); colIndex++) {
+      Column col = this.getDDF().getSchema().getColumn(colIndex);
+
+      if (!col.isNumeric() || col.getColumnClass() == ColumnClass.FACTOR
+              || ((columns != null) && (!columns.isEmpty()) && (!columns.contains(col.getName()))) ) {
+        sqlCmdBuffer.append(col.getName()).append(",");
+      } else {
+        if (summaryArr[colIndex] == null) {
+          LOG.warn("Missing column summary. transformScaleStandard ignored for column: " + col.getName());
+
+          sqlCmdBuffer.append(col.getName()).append(" ");
+        } else if (summaryArr[colIndex].stdev() == 0) {
+          LOG.warn("standard deviation equals zero. transformScaleStandard ignored for column: " + col.getName());
+
+          sqlCmdBuffer.append(col.getName()).append(" ");
+        } else {
+          // subtract mean, divide by stdev
+          sqlCmdBuffer.append(String
+                  .format("((%s - %s) / %s) as %s ", col.getName(), summaryArr[colIndex].mean(), summaryArr[colIndex].stdev(),
+                          col.getName()));
+        }
+
+        sqlCmdBuffer.append(",");
+      }
+    }
+    sqlCmdBuffer.setLength(sqlCmdBuffer.length() - 1);
+    sqlCmdBuffer.append(" FROM ").append(this.getDDF().getTableName());
+
+    DDF newddf = this.getManager().sql2ddf(sqlCmdBuffer.toString(), this.getEngine());
+    newddf.getMetaDataHandler().copyFactor(this.getDDF());
+
+    return inPlace ? this.getDDF().updateInplace(newddf) : newddf;
   }
 
   @Override public DDF transformNativeRserve(String transformExpression) {

--- a/core/src/main/java/io/ddf/etl/TransformationHandler.java
+++ b/core/src/main/java/io/ddf/etl/TransformationHandler.java
@@ -41,8 +41,7 @@ public class TransformationHandler extends ADDFFunctionalGroupHandler implements
     for (int colIndex = 0; colIndex < this.getDDF().getSchema().getNumColumns(); colIndex++) {
       Column col = this.getDDF().getSchema().getColumn(colIndex);
 
-      if (!col.isNumeric() || col.getColumnClass() == ColumnClass.FACTOR
-              || ((columns != null) && (!columns.isEmpty()) && (!columns.contains(col.getName()))) ) {
+      if (!isColumnEligibleToScale(col, columns)) {
         sqlCmdBuffer.append(col.getName()).append(",");
       } else {
         if (summaryArr[colIndex] == null) {
@@ -85,8 +84,7 @@ public class TransformationHandler extends ADDFFunctionalGroupHandler implements
     for (int colIndex = 0; colIndex < this.getDDF().getSchema().getNumColumns(); colIndex++) {
       Column col = this.getDDF().getSchema().getColumn(colIndex);
 
-      if (!col.isNumeric() || col.getColumnClass() == ColumnClass.FACTOR
-              || ((columns != null) && (!columns.isEmpty()) && (!columns.contains(col.getName()))) ) {
+      if (!isColumnEligibleToScale(col, columns)) {
         sqlCmdBuffer.append(col.getName()).append(",");
       } else {
         if (summaryArr[colIndex] == null) {
@@ -496,5 +494,11 @@ public class TransformationHandler extends ADDFFunctionalGroupHandler implements
     } else {
       return castType(column, newType);
     }
+  }
+
+  private boolean isColumnEligibleToScale(Column column, List<String> scaleRequestedColumnNames) {
+    return (column.isNumeric()
+            && column.getColumnClass() != ColumnClass.FACTOR
+            && ((scaleRequestedColumnNames == null) || scaleRequestedColumnNames.isEmpty() || scaleRequestedColumnNames.contains(column.getName())));
   }
 }

--- a/core/src/main/java/io/ddf/facades/TransformFacade.java
+++ b/core/src/main/java/io/ddf/facades/TransformFacade.java
@@ -85,8 +85,18 @@ public class TransformFacade implements IHandleTransformations {
   }
 
   @Override
+  public DDF transformScaleMinMax(List<String> columns, Boolean inPlace) throws DDFException {
+    return mTransformationHandler.transformScaleMinMax(columns, inPlace);
+  }
+
+  @Override
   public DDF transformScaleStandard() throws DDFException {
     return mTransformationHandler.transformScaleStandard();
+  }
+
+  @Override
+  public DDF transformScaleStandard(List<String> columns, Boolean inPlace) throws DDFException {
+    return mTransformationHandler.transformScaleStandard(columns, inPlace);
   }
 
   @Override

--- a/ddf-test/src/main/scala/io/ddf/test/it/etl/TransformationHandlerBaseSuite.scala
+++ b/ddf-test/src/main/scala/io/ddf/test/it/etl/TransformationHandlerBaseSuite.scala
@@ -152,6 +152,28 @@ trait TransformationHandlerBaseSuite extends BaseSuite with Matchers {
     arr.get(2)(8) should be("WN")
   }
 
+  test("transform scale min max empty list of columns") {
+    val originalDDF: DDF = loadAirlineDDF().VIEWS.project("Year", "Month", "DayofMonth", "DayofWeek", "DepTime",
+      "CRSDepTime", "ArrTime", "CRSArrTime", "UniqueCarrier", "FlightNum", "TailNum")
+    val originalDDFSummary: Array[Summary] = originalDDF.getSummary
+
+    val columnsToScale = List()
+    val scaledDDF: DDF = originalDDF.Transform.transformScaleMinMax(columnsToScale, false)
+    val scaledDDFSummary: Array[Summary] = scaledDDF.getSummary
+    scaledDDF should not be null
+    scaledDDF.getNumRows should be(originalDDF.getNumRows)
+    scaledDDF.getNumColumns should be(originalDDF.getNumColumns)
+
+    for (i <- 0 until scaledDDF.getNumColumns ) {
+      if (originalDDFSummary(i) != null) {
+        scaledDDFSummary(i).min should be(originalDDFSummary(i).min)
+        scaledDDFSummary(i).max should be(originalDDFSummary(i).max)
+      } else {
+        scaledDDFSummary(i) should be(null)
+      }
+    }
+  }
+
   test("transform scale min max inPlace false") {
     val inPlace = false
     val originalDDF: DDF = loadAirlineDDF().VIEWS.project("Year", "Month", "DayofMonth", "DayofWeek", "DepTime",
@@ -173,7 +195,7 @@ trait TransformationHandlerBaseSuite extends BaseSuite with Matchers {
       "CRSDepTime", "ArrTime", "CRSArrTime", "UniqueCarrier", "FlightNum", "TailNum")
     val originalDDFSummary: Array[Summary] = originalDDF.getSummary
 
-    val scaledDDF: DDF = originalDDF.Transform.transformScaleMinMax(List(), inPlace)
+    val scaledDDF: DDF = originalDDF.Transform.transformScaleMinMax(null, inPlace)
     scaledDDF should not be null
     scaledDDF.getNumRows should be(31)
     scaledDDF.getNumColumns should be(11)
@@ -271,6 +293,28 @@ trait TransformationHandlerBaseSuite extends BaseSuite with Matchers {
     arr.get(0)(8) should be("WN")
     arr.get(1)(8) should be("WN")
     arr.get(2)(8) should be("WN")
+  }
+
+  test("transform scale standard empty list of columns") {
+    val originalDDF: DDF = loadAirlineDDF().VIEWS.project("Year", "Month", "DayofMonth", "DayofWeek", "DepTime",
+      "CRSDepTime", "ArrTime", "CRSArrTime", "UniqueCarrier", "FlightNum", "TailNum")
+    val originalDDFSummary: Array[Summary] = originalDDF.getSummary
+
+    val columnsToScale = List()
+    val scaledDDF: DDF = originalDDF.Transform.transformScaleStandard(columnsToScale, false)
+    val scaledDDFSummary: Array[Summary] = scaledDDF.getSummary
+    scaledDDF should not be null
+    scaledDDF.getNumRows should be(originalDDF.getNumRows)
+    scaledDDF.getNumColumns should be(originalDDF.getNumColumns)
+
+    for (i <- 0 until scaledDDF.getNumColumns ) {
+      if (originalDDFSummary(i) != null) {
+        scaledDDFSummary(i).min should be(originalDDFSummary(i).min)
+        scaledDDFSummary(i).max should be(originalDDFSummary(i).max)
+      } else {
+        scaledDDFSummary(i) should be(null)
+      }
+    }
   }
 
   test("transform scale standard inPlace false") {


### PR DESCRIPTION
### Description and related tickets, documents
Add support to scale a subset of columns (to both scaleMinMax and scaleStandard)
Add inPlace flag (to both scaling methods)
- https://adatao.atlassian.net/browse/PE-1774
- https://adatao.atlassian.net/browse/PE-1898
- https://adatao.atlassian.net/browse/PE-1897

Reviewers: @hai-adatao @Huandao0812 @nhanitvn @phvu @lebinh @ubolonton @zkidkid 

### Breaking changes & backward compatible issues
None

### How to test
Unit tests

### PR Progress
Make sure all checkboxes below are checked before merged
- [x] Branch is in format `prefix/description` (see [this](http://www.guyroutledge.co.uk/blog/git-branch-naming-conventions/))
- [x] Merge check has no conflicts. PR checks passed.
- [ ] Code review is done. 