### PR TITLE
Refactor and optimize sampling by size

### DIFF
--- a/core/src/main/java/io/ddf/facades/ViewsFacade.java
+++ b/core/src/main/java/io/ddf/facades/ViewsFacade.java
@@ -43,7 +43,7 @@ public class ViewsFacade implements IHandleViews {
   }
 
   @Override
-  public DDF getRandomSampleByNum(long numSamples, boolean withReplacement,
+  public DDF getRandomSampleByNum(int numSamples, boolean withReplacement,
                                   int seed) {
     return mViewHandler.getRandomSampleByNum(numSamples, withReplacement, seed);
   }

--- a/core/src/main/java/io/ddf/facades/ViewsFacade.java
+++ b/core/src/main/java/io/ddf/facades/ViewsFacade.java
@@ -43,7 +43,7 @@ public class ViewsFacade implements IHandleViews {
   }
 
   @Override
-  public DDF getRandomSampleByNum(int numSamples, boolean withReplacement,
+  public DDF getRandomSampleByNum(long numSamples, boolean withReplacement,
                                   int seed) {
     return mViewHandler.getRandomSampleByNum(numSamples, withReplacement, seed);
   }

--- a/spark/src/main/scala/io/ddf/spark/content/ViewHandler.scala
+++ b/spark/src/main/scala/io/ddf/spark/content/ViewHandler.scala
@@ -67,29 +67,22 @@ class ViewHandler(mDDF: DDF) extends io.ddf.content.ViewHandler(mDDF) with IHand
       throw new IllegalArgumentException("Number of samples must be larger than or equal to 0")
     }
 
-    val sampleDDF = if (!withReplacement) {
-      if (seed >= 0) {
-        mDDF.getSqlHandler.sql2ddf(s"select * from ${mDDF.getSchema.getTableName} order by rand($seed) limit $numSamples")
-      } else {
-        // This is a workaround to deal with Spark's inability to order rows by rand(<negative_seed>)
-        // Example: select * from table order by rand(-123)
-        mDDF.getSqlHandler.sql2ddf(s"select ${mDDF.getColumnNames.mkString(",")} from " +
-          s"(select *, rand($seed) as rnd from ${mDDF.getSchema.getTableName}) t order by rnd limit $numSamples")
-      }
-    } else {
+    val numRows = mDDF.getNumRows
+    var fraction = 1.0
+    // We use Spark's API to sample twice what we need, then only pick the first numSamples rows.
+    if (withReplacement) fraction = 2.0 * numSamples / numRows
 
-      val numRows = mDDF.getNumRows
-      val rddRow: RDD[Row] = mDDF.asInstanceOf[SparkDDF].getRDD(classOf[Row])
-      // We use Spark's API to sample twice what we need, then only pick the first numSamples rows.
-      val sampledRDD = rddRow.sample(true, 2.0 * numSamples / numRows, seed).zipWithIndex().filter(_._2 < numSamples).map(_._1)
+    val rddRow: RDD[Row] = mDDF.asInstanceOf[SparkDDF].getRDD(classOf[Row])
+    val sampledRDD = rddRow.sample(true, fraction, seed).zipWithIndex().filter(_._2 < numSamples).map(_._1)
 
-      val manager = this.getManager
-      val schema: Schema = new Schema(null,
-        JavaConverters.asScalaBufferConverter(mDDF.getSchema.getColumns).asScala.toArray)
-      manager.newDDF(sampledRDD, Array(classOf[RDD[_]], classOf[Row]), manager.getNamespace, null, schema)
-    }
+    val manager = this.getManager
+    val schema: Schema = new Schema(null,
+      JavaConverters.asScalaBufferConverter(mDDF.getSchema.getColumns).asScala.toArray)
+    val sampleDDF = manager.newDDF(sampledRDD, Array(classOf[RDD[_]], classOf[Row]), manager.getNamespace, null, schema)
+
     // Copy Factor info
     sampleDDF.getMetaDataHandler.copyFactor(mDDF)
+
     sampleDDF
   }
 


### PR DESCRIPTION
### Description and related tickets, documents
- Use Spark DF/RDD API for performing sampling instead of SQL
- Also provide an optimized way of sampling for integer sample sizes using Spark DF sample and limit.

Reviewers: @hai-adatao @Huandao0812 @phvu 

### Breaking changes & backward compatible issues

### How to test
Need to be deployed on a cluster with big enough datasets such as NYC taxi to test for the error on spark.driver.maxResultSize @thxph 

### PR Progress
Make sure all checkboxes below are checked before merged
- [x] Branch is in format `prefix/description` (see [this](http://www.guyroutledge.co.uk/blog/git-branch-naming-conventions/))
- [ ] Merge check has no conflicts. PR checks passed.
- [ ] Code review is done. 
