### PR TITLE
[BIGAPPS-6226] Fix not being able to run SQL on DDF

### DIFF
--- a/core/src/main/java/io/ddf/DDFCache.java
+++ b/core/src/main/java/io/ddf/DDFCache.java
@@ -138,6 +138,10 @@ public class DDFCache extends ALoggable {
             ddf = mDDFwithNameCache.getIfPresent(uuid);
             if (ddf == null) {
               ddf = mDDFManager.restoreDDF(uuid);
+              // XXX: hot fix for not being able to run SQL on DDF, this might not belong here
+              // this is needed because DDFCoordinator keeps a mapping between DDF <-> DDFManager
+              // and SQL API uses that map to figure out which DDFManager should be used to run given a query
+              mDDFManager.getDDFCoordinator().addDDF(ddf);
             }
             if (ddf.getName() != null) {
               mDDFwithNameCache.put(uuid, ddf);


### PR DESCRIPTION
### Description and related tickets, documents
Hot fix for not being able to run SQL API on DDF. This is needed because DDFCoordinator keeps a mapping between DDF <-> DDFManager and SQL API uses that map to figure out which DDFManager should be used to run given a query.

Reviewers: @Huandao0812 @hai-adatao @nhanitvn 

### Breaking changes & backward compatible issues
NA

### How to test
NA

### PR Progress
Make sure all checkboxes below are checked before merged
- [x] Branch is in format `prefix/description` (see [this](http://www.guyroutledge.co.uk/blog/git-branch-naming-conventions/))
- [ ] Merge check has no conflicts. PR checks passed.
- [ ] Code review is done. 
