### PR TITLE
temporary fix for S3DDF/HDFSDDF not recognizing lower-case format names

### DIFF
--- a/hdfs/src/main/java/io/ddf/hdfs/HDFSDDF.java
+++ b/hdfs/src/main/java/io/ddf/hdfs/HDFSDDF.java
@@ -53,20 +53,21 @@ public class HDFSDDF extends DDF {
         }
         // Check directory or file.
         HDFSDDFManager hdfsDDFManager = this.getManager();
+        mIsDir = hdfsDDFManager.isDir(this);
         // Check dataformat.
         if (options != null && options.containsKey("format")) {
             try {
                 String format = options.get("format").toUpperCase();
                 format = format.equals("PARQUET") ? "PQT" : format;
-                mDataFormat = DataFormat.valueOf(options.get("format"));
+                mDataFormat = DataFormat.valueOf(format);
             } catch (IllegalArgumentException e) {
-                mIsDir = hdfsDDFManager.isDir(this);
+                // TODO: Disable automatic format choosing, or put it under a convenience flag.
                 mDataFormat = hdfsDDFManager.getDataFormat(this);
             }
         } else {
-            mIsDir = hdfsDDFManager.isDir(this);
             mDataFormat = hdfsDDFManager.getDataFormat(this);
         }
+        mLog.info(String.format("HDFS data format %s", mDataFormat));
     }
 
     public DataFormat getDataFormat() {

--- a/hdfs/src/test/java/io/ddf/hdfs/HDFSDDFManagerTests.java
+++ b/hdfs/src/test/java/io/ddf/hdfs/HDFSDDFManagerTests.java
@@ -6,7 +6,9 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import io.ddf.datasource.DataFormat;
 import io.ddf.exception.DDFException;
@@ -42,6 +44,12 @@ public class HDFSDDFManagerTests {
         assert (files.size() > 0);
     }
 
+    private Map<String, String> withFormat(String format) {
+        Map<String, String> options = new HashMap<>();
+        options.put("format", format);
+        return options;
+    }
+
     @Test
     public void testCreateDDF() throws DDFException {
         HDFSDDF cleanFolderDDF = manager.newDDF("/test_pe/csv/multiple", null, null);
@@ -70,12 +78,19 @@ public class HDFSDDFManagerTests {
         assert (pqtDDF.getIsDir() == true);
         assert (pqtDDF.getDataFormat().equals(DataFormat.PQT));
 
-
         HDFSDDF avroDDF = manager.newDDF("/test_pe/avro/single", null, null);
         assert (avroDDF.getIsDir() == true);
         assert (avroDDF.getDataFormat().equals(DataFormat.AVRO));
 
+        avroDDF = manager.newDDF("/test_pe/avro/single", null, withFormat("AVRO"));
+        assert (avroDDF.getIsDir() == true);
+        assert (avroDDF.getDataFormat().equals(DataFormat.AVRO));
+
         HDFSDDF orcDDF = manager.newDDF("/test_pe/orc/default", null, null);
+        assert (orcDDF.getIsDir() == true);
+        assert (orcDDF.getDataFormat().equals(DataFormat.ORC));
+
+        orcDDF = manager.newDDF("/test_pe/orc/default", null, withFormat("orc"));
         assert (orcDDF.getIsDir() == true);
         assert (orcDDF.getDataFormat().equals(DataFormat.ORC));
 

--- a/s3/src/main/java/io/ddf/s3/S3DDF.java
+++ b/s3/src/main/java/io/ddf/s3/S3DDF.java
@@ -89,20 +89,21 @@ public class S3DDF extends DDF {
         mLog.info(String.format("Initialize s3 ddf: %s %s", mBucket, mKey));
         // Check directory or file.
         S3DDFManager s3DDFManager = this.getManager();
+        mIsDir = s3DDFManager.isDir(this);
         // Check dataformat.
         if (options != null && options.containsKey("format")) {
             try {
                 String format = options.get("format").toUpperCase();
                 format = format.equals("PARQUET") ? "PQT" : format;
-                mDataFormat = DataFormat.valueOf(options.get("format"));
+                mDataFormat = DataFormat.valueOf(format);
             } catch (IllegalArgumentException e) {
-                mIsDir = s3DDFManager.isDir(this);
+                // TODO: Disable automatic format choosing, or put it under a convenience flag.
                 mDataFormat = s3DDFManager.getDataFormat(this);
             }
         } else {
-            mIsDir = s3DDFManager.isDir(this);
             mDataFormat = s3DDFManager.getDataFormat(this);
         }
+        mLog.info(String.format("S3 data format %s", mDataFormat));
     }
 
     public DataFormat getDataFormat() {

--- a/s3/src/test/java/io/ddf/s3/S3DDFManagerTests.java
+++ b/s3/src/test/java/io/ddf/s3/S3DDFManagerTests.java
@@ -90,6 +90,12 @@ public class S3DDFManagerTests {
         }
     }
 
+    private Map<String, String> withFormat(String format) {
+        Map<String, String> options = new HashMap<>();
+        options.put("format", format);
+        return options;
+    }
+
     @Test
     public void testCreateDDF() throws DDFException {
         try {
@@ -122,12 +128,9 @@ public class S3DDFManagerTests {
         assert (pqtDDF.getIsDir() == true);
         assert (pqtDDF.getDataFormat().equals(DataFormat.PQT));
 
-        Map<String, String> options = new HashMap<>();
-        options.put("format", "parquet");
-        S3DDF pqtDDFWithOpts = manager.newDDF("adatao-sample-data", "test/parquet/sleep_parquet/", null, options);
+        S3DDF pqtDDFWithOpts = manager.newDDF("adatao-sample-data", "test/parquet/sleep_parquet/", null, withFormat("parquet"));
         assert (pqtDDFWithOpts.getIsDir() == true);
         assert (pqtDDF.getDataFormat().equals(DataFormat.PQT));
-
 
         S3DDF avroDDF = manager.newDDF("adatao-sample-data", "test/avro/single/twitter.avro", null, null);
         assert (avroDDF.getIsDir() == false);
@@ -136,6 +139,10 @@ public class S3DDFManagerTests {
         S3DDF orcDDF = manager.newDDF("adatao-test", "orc/", null, null);
         assert (orcDDF.getIsDir() == true);
         assert (orcDDF.getDataFormat().equals(DataFormat.ORC));
+
+        // Need to accept lower case
+        orcDDF = manager.newDDF("adatao-test", "orc/", null, withFormat("orc"));
+        assert (orcDDF.getDataFormat().equals((DataFormat.ORC)));
 
         S3DDF noExtensionDDF = manager.newDDF("adatao-sample-data/test/csv/withheader");
 


### PR DESCRIPTION
### Description and related tickets, documents
Temporary fix for S3DDF and HDFSDDF not recognizing lower-case format names.
E.g. It treated `orc` as unknown format, thus falling back to the default of `csv`.

Reviewers: @PangZhi @Huandao0812 @hai-adatao 

### Breaking changes & backward compatible issues
No

### How to test
UT
@hai-adatao We need to add more client-side tests for cases where specified format does not agree with file extensions (though we'd better remove the automatic format inference).

### PR Progress
Make sure all checkboxes below are checked before merged
- [X] Branch is in format `prefix/description` (see [this](http://www.guyroutledge.co.uk/blog/git-branch-naming-conventions/))
- [x] Merge check has no conflicts. PR checks passed.
- [x] Code review is done. 

