### PR TITLE
[PE-2058] Improve load from S3 speed by using s3a instead of s3n

### DIFF
--- a/core/src/main/java/io/ddf/datasource/S3DataSourceURI.java
+++ b/core/src/main/java/io/ddf/datasource/S3DataSourceURI.java
@@ -39,13 +39,13 @@ public class S3DataSourceURI extends DataSourceURI {
         if (this.awsKeyID != null && this.awsSecretKey != null) {
             String creds = this.awsKeyID + ":" + this.awsSecretKey + "@";
             try {
-                return new URI("s3n://" + creds + this.mUri.toString());
+                return new URI("s3a://" + creds + this.mUri.toString());
             } catch (URISyntaxException e) {
                 e.printStackTrace();
             }
         } else {
             try {
-                return new URI("s3n://" + this.mUri.toString());
+                return new URI("s3a://" + this.mUri.toString());
             } catch (URISyntaxException e) {
                 e.printStackTrace();
             }

--- a/project/RootBuild.scala
+++ b/project/RootBuild.scala
@@ -111,7 +111,7 @@ object RootBuild extends Build {
   )
 
   val s3_dependencies = Seq(
-    "com.amazonaws" % "aws-java-sdk" % "1.7.4" exclude("com.fasterxml.jackson.core", "jackson-core"),
+    "com.amazonaws" % "aws-java-sdk" % "1.7.4",
     "org.apache.hadoop" % "hadoop-common" % "2.7.2" exclude("org.mortbay.jetty", "servlet-api") exclude("commons-httpclient", "commons-httpclient") exclude ("org.apache.httpcomponents", "httpcore"),
    "org.apache.httpcomponents" % "httpcore" % "4.4.1"
   )
@@ -279,6 +279,7 @@ object RootBuild extends Build {
     dependencyOverrides += "org.codehaus.jackson" % "jackson-mapper-asl" % "1.8.8",
     dependencyOverrides += "org.codehaus.jackson" % "jackson-xc" % "1.8.8",
     dependencyOverrides += "org.codehaus.jackson" % "jackson-jaxrs" % "1.8.8",
+    dependencyOverrides += "com.fasterxml.jackson.core" % "jackson-core" % "2.4.4",
     dependencyOverrides += "com.fasterxml.jackson.core" % "jackson-databind" % "2.4.4",
     dependencyOverrides += "com.fasterxml.jackson.core" % "jackson-annotations" % "2.4.4",
     dependencyOverrides += "com.thoughtworks.paranamer" % "paranamer" % "2.4.1", //net.liftweb conflict with avro

--- a/project/RootBuild.scala
+++ b/project/RootBuild.scala
@@ -111,7 +111,7 @@ object RootBuild extends Build {
   )
 
   val s3_dependencies = Seq(
-    "com.amazonaws" % "aws-java-sdk" % "1.10.8",
+    "com.amazonaws" % "aws-java-sdk" % "1.7.4",
     "org.apache.hadoop" % "hadoop-common" % "2.7.2" exclude("org.mortbay.jetty", "servlet-api") exclude("commons-httpclient", "commons-httpclient") exclude ("org.apache.httpcomponents", "httpcore"),
    "org.apache.httpcomponents" % "httpcore" % "4.4.1"
   )

--- a/project/RootBuild.scala
+++ b/project/RootBuild.scala
@@ -111,7 +111,7 @@ object RootBuild extends Build {
   )
 
   val s3_dependencies = Seq(
-    "com.amazonaws" % "aws-java-sdk" % "1.7.4",
+    "com.amazonaws" % "aws-java-sdk" % "1.7.4" exclude("com.fasterxml.jackson.core", "jackson-core"),
     "org.apache.hadoop" % "hadoop-common" % "2.7.2" exclude("org.mortbay.jetty", "servlet-api") exclude("commons-httpclient", "commons-httpclient") exclude ("org.apache.httpcomponents", "httpcore"),
    "org.apache.httpcomponents" % "httpcore" % "4.4.1"
   )

--- a/s3/pom.xml
+++ b/s3/pom.xml
@@ -311,7 +311,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk</artifactId>
-            <version>1.10.8</version>
+            <version>1.7.4</version>
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>

--- a/s3/src/main/java/io/ddf/s3/S3DDFManager.java
+++ b/s3/src/main/java/io/ddf/s3/S3DDFManager.java
@@ -277,7 +277,7 @@ public class S3DDFManager extends DDFManager {
 
   @Override
   public String getSourceUri() {
-    return "s3n://" + mCredential.getAwsKeyID() + ":" + mCredential.getAwsScretKey();
+    return "s3a://" + mCredential.getAwsKeyID() + ":" + mCredential.getAwsScretKey();
 
   }
 

--- a/spark/src/main/java/io/ddf/spark/SparkDDFManager.java
+++ b/spark/src/main/java/io/ddf/spark/SparkDDFManager.java
@@ -272,7 +272,7 @@ public class SparkDDFManager extends DDFManager {
       if (ddf instanceof S3DDF) {
         S3DDF s3DDF = (S3DDF) ddf;
         S3DataSourceCredentials cred = s3DDF.getManager().getCredential();
-        uri = String.format("s3n://%s:%s@%s/%s", cred.getAwsKeyID(), cred.getAwsScretKey(),
+        uri = String.format("s3a://%s:%s@%s/%s", cred.getAwsKeyID(), cred.getAwsScretKey(),
             s3DDF.getBucket(), s3DDF.getKey());
         dataFormat = s3DDF.getDataFormat();
         if (s3DDF.getSchemaString() != null) {

--- a/spark/src/main/scala/io/ddf/spark/ds/FileDataSource.scala
+++ b/spark/src/main/scala/io/ddf/spark/ds/FileDataSource.scala
@@ -123,7 +123,7 @@ class S3DataSource(uri: String, manager: DDFManager) extends FileDataSource(uri,
           case Some(credential: UsernamePasswordCredential) =>
             val username = credential.getUsername
             val password = credential.getPassword
-            s"s3n://$username:$password@$bucket$absolutePath"
+            s"s3a://$username:$password@$bucket$absolutePath"
           case Some(cred) =>
             throw new UnauthenticatedDataSourceException(s"Incompatible credential for S3 source: $cred")
           case None =>


### PR DESCRIPTION
### Description and related tickets, documents

Replace `s3n` file system with `s3a` as it is faster and is stabilized enough in Hadoop 2.7 (https://wiki.apache.org/hadoop/AmazonS3).
### Performance comparison

Create DDF from S3 with PyClient
![image](https://cloud.githubusercontent.com/assets/234997/15957421/5c5ddd6a-2f19-11e6-8871-f35bafe3ccb3.png)

Create dataset from S3 in BigApps
![image](https://cloud.githubusercontent.com/assets/234997/15957419/54d22ad8-2f19-11e6-924f-17c13142af36.png)

Related:
- https://adatao.atlassian.net/browse/PE-2058

Reviewers: 
- Main reviewer: @PangZhi @Huandao0812
- Observers: @hai-adatao, @SeineRiver
### Breaking changes & backward compatible issues

NA as `s3a` should be a drop in replacement for `s3n`.
### PR Progress

Make sure all checkboxes below are checked before merged
- [x] Merge check has no conflicts. PR checks passed.
- [ ] Main reviewer approved
- [ ] Optional reviewer approved
