### PR TITLE
Remove unused dependencies

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -326,6 +326,42 @@
                     <groupId>javax.servlet</groupId>
                     <artifactId>servlet-api</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>com.sun.xml.bind</groupId>
+                    <artifactId>jaxb-impl</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.servlet.jsp</groupId>
+                    <artifactId>jsp-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-math</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.sun.jersey</groupId>
+                    <artifactId>jersey-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.codehaus.jackson</groupId>
+                    <artifactId>jackson-jaxrs</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>stax</groupId>
+                    <artifactId>stax-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.sun.jersey</groupId>
+                    <artifactId>jersey-json</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.hadoop</groupId>
+                    <artifactId>hadoop-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.sun.jersey</groupId>
+                    <artifactId>jersey-server</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>


### PR DESCRIPTION
@hai-adatao Hi, I am a user of project **_io.ddf:ddf_core_2.10:1.5.0-SNAPSHOT_**. I found that its pom file introduced **_78_** dependencies. However, among them, **_15_** libraries (**_19%_**) have not been used by your project (the redundant dependencies are listed below). This PR helps **_io.ddf:ddf_core_2.10:1.5.0-SNAPSHOT_** lose weight :) I have tested the revised configuration in my local environment. It is safe to remove the unused libraries.

Best regards


## Redundant dependencies----
<pre><code>
org.codehaus.jackson:jackson-xc:jar:1.8.3:compile
com.sun.jersey:jersey-json:jar:1.9:compile
com.sun.xml.bind:jaxb-impl:jar:2.2.3-1:compile
jdk.tools:jdk.tools:jar:1.6:system
com.sun.jersey:jersey-core:jar:1.9:compile
javax.servlet.jsp:jsp-api:jar:2.1:runtime
com.sun.jersey:jersey-server:jar:1.9:compile
org.apache.commons:commons-math:jar:2.1:compile
org.apache.hadoop:hadoop-annotations:jar:2.2.0:compile
javax.xml.bind:jaxb-api:jar:2.2.2:compile
org.codehaus.jackson:jackson-jaxrs:jar:1.8.3:compile
javax.activation:activation:jar:1.1:compile
asm:asm:jar:3.1:compile
org.codehaus.jettison:jettison:jar:1.1:compile
stax:stax-api:jar:1.0.1:compile
</code></pre>
